### PR TITLE
Backport the patches from 7.100 to 7.98, required for downstream build

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -10,12 +10,12 @@
 
 # The image to get the Node.js binary to support running an IDE in a UBI8-based user container.
 # https://registry.access.redhat.com/ubi8/nodejs-20
-FROM registry.access.redhat.com/ubi8/nodejs-20:1-71 as ubi8
+FROM registry.access.redhat.com/ubi8/nodejs-20:1-72 as ubi8
 
 # Base image tag updater line.
 # See https://github.com/eclipse-che/che-release/pull/90
 # https://registry.access.redhat.com/ubi9/nodejs-20
-FROM registry.access.redhat.com/ubi9/nodejs-20:9.5-1734597699
+FROM registry.access.redhat.com/ubi9/nodejs-20:9.5-1739482759
 
 # Dockerfile for building a container that brings everything needed to:
 # - install Jet Brains IDE to a Dev Workspace
@@ -25,6 +25,8 @@ USER 0
 
 COPY --chmod=755 /build/scripts/*.sh /
 COPY /status-app/ /status-app/
+# Copy the JetBrains IDE's config where some settings are overridden for Che CDE needs.
+COPY /build/jetbrains_configs/idea.properties/ /
 
 # Create a folders structure for mounting a shared volume and copy the editor binaries to.
 RUN mkdir -p /idea-server/status-app

--- a/build/jetbrains_configs/idea.properties
+++ b/build/jetbrains_configs/idea.properties
@@ -1,0 +1,8 @@
+# JetBrains IDE's configuration with some settings is overridden for Che CDE needs.
+
+
+# customize a path to the settings directory
+idea.config.path=${user.home}/.jetbrains-che/config
+
+# customize a path to the user-installed plugins directory
+idea.plugins.path=${idea.config.path}/plugins

--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -30,28 +30,28 @@ echo "Downloading IDE binaries..."
 ide_download_url=""
 case $ide_flavour in
   idea)
-    ide_download_url="https://download.jetbrains.com/idea/ideaIU-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/idea/ideaIU-2024.3.2.1.tar.gz"
     ;;
   webstorm)
-    ide_download_url="https://download.jetbrains.com/webstorm/WebStorm-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/webstorm/WebStorm-2024.3.2.1.tar.gz"
     ;;
   pycharm)
-    ide_download_url="https://download.jetbrains.com/python/pycharm-professional-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/python/pycharm-professional-2024.3.2.tar.gz"
     ;;
   goland)
-    ide_download_url="https://download.jetbrains.com/go/goland-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/go/goland-2024.3.2.1.tar.gz"
     ;;
   clion)
-    ide_download_url="https://download.jetbrains.com/cpp/CLion-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/cpp/CLion-2024.3.2.tar.gz"
     ;;
   phpstorm)
-    ide_download_url="https://download.jetbrains.com/webide/PhpStorm-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/webide/PhpStorm-2024.3.2.1.tar.gz"
     ;;
   rubymine)
-    ide_download_url="https://download.jetbrains.com/ruby/RubyMine-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/ruby/RubyMine-2024.3.2.1.tar.gz"
     ;;
   rider)
-    ide_download_url="https://download.jetbrains.com/rider/JetBrains.Rider-2024.2.3.tar.gz"
+    ide_download_url="https://download.jetbrains.com/rider/JetBrains.Rider-2024.3.4.tar.gz"
     ;;
   *)
     echo -n "Unknown IDE is specified: $ide_flavour"
@@ -62,6 +62,9 @@ curl -sL "$ide_download_url" | tar xzf - --strip-components=1
 
 cp -r /status-app/ "$ide_server_path"
 cp /entrypoint-volume.sh "$ide_server_path"
+
+# Copy the Che-specific JetBrains IDE's config to the volume.
+cp /idea.properties "$ide_server_path"
 
 # Copy Node.js binaries to the editor volume.
 # It will be copied to the user container if it's absent.

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -106,5 +106,8 @@ else
   nohup "$ide_server_path"/node index.js &
 fi
 
+# Override the default JetBrains IDE's config by our own.
+mv "$ide_server_path"/idea.properties "${HOME}/idea.properties"
+
 cd "$ide_server_path"/bin
 ./remote-dev-server.sh run ${PROJECT_SOURCE}


### PR DESCRIPTION
The [downstream build](https://github.com/redhat-developer/devspaces-images/pull/730) requires a few patches to be backported from 7.100 to 7.98.