### PR TITLE
Support the UBI9-based user containers

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -25,8 +25,6 @@ USER 0
 
 COPY --chmod=755 /build/scripts/*.sh /
 COPY /status-app/ /status-app/
-# Copy the JetBrains IDE's config where some settings are overridden for Che CDE needs.
-COPY /build/jetbrains_configs/idea.properties/ /
 
 # Create a folder structure for mounting a shared volume and copy the editor binaries.
 RUN mkdir -p /idea-server/status-app
@@ -41,7 +39,11 @@ RUN for f in "${HOME}" "/etc/passwd" "/etc/group" "/status-app" "/idea-server"; 
 WORKDIR /status-app/
 RUN npm install
 
-# to provide to a UBI8-based user's container
+# When registry.access.redhat.com/ubi9 is used as a user container,
+# there no libbrotli in the image. We provide it additionally to the user's container.
+RUN mkdir /node-ubi9-ld_libs && cp -r /usr/lib64/libbrotli* /node-ubi9-ld_libs/
+
+# To make the solution backward compatible with the UBI8-based user containers.
 COPY --from=ubi8 /usr/bin/node /node-ubi8
 
 # Switch to an unprivileged user.

--- a/build/jetbrains_configs/idea.properties
+++ b/build/jetbrains_configs/idea.properties
@@ -1,8 +1,0 @@
-# JetBrains IDE's configuration with some settings is overridden for Che CDE needs.
-
-
-# customize a path to the settings directory
-idea.config.path=${user.home}/.jetbrains-che/config
-
-# customize a path to the user-installed plugins directory
-idea.plugins.path=${idea.config.path}/plugins

--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -24,7 +24,7 @@ if [ -z "$ide_flavour" ]; then
 fi
 
 # Download the IDE binaries and install them to the shared volume.
-cd "$ide_server_path"
+cd "$ide_server_path" || exit
 echo "Downloading IDE binaries..."
 # After updating the versions here, update the editor definitions in https://github.com/eclipse-che/che-operator/tree/main/editors-definitions
 ide_download_url=""
@@ -63,13 +63,11 @@ curl -sL "$ide_download_url" | tar xzf - --strip-components=1
 cp -r /status-app/ "$ide_server_path"
 cp /entrypoint-volume.sh "$ide_server_path"
 
-# Copy the Che-specific JetBrains IDE's config to the volume.
-cp /idea.properties "$ide_server_path"
-
 # Copy Node.js binaries to the editor volume.
 # It will be copied to the user container if it's absent.
 cp /usr/bin/node "$ide_server_path"/node-ubi9
 cp /node-ubi8 "$ide_server_path"/node-ubi8
+cp -r /node-ubi9-ld_libs "$ide_server_path"/node-ubi9-ld_libs
 
 echo "Volume content:"
 ls -la "$ide_server_path"


### PR DESCRIPTION
This is part of the fix for supporting the user containers based on the registry.access.redhat.com/ubi9.
https://issues.redhat.com/browse/CRW-8294
The other part is https://github.com/redhat-developer/devspaces-gateway-plugin/pull/125.

There are two problems fixed.
1. When using `registry.access.redhat.com/ubi9` image for a user container, there are no `libbrotli` libraries that are required for running the Node.js binary. The PR adds providing the `libbrotli` libraries to the user container through the `LD_LIBRARY_PATH` environment variable.
2. When running a remote IDE server in the user container, it writes to several sub-folders of `HOME` (.config, .cache, etc.)
In case of `registry.access.redhat.com/ubi9`, `HOME=/`, which is read-only. To allow such commands to be run, we set `HOME` for the running command to a writable location.
