### PR TITLE
Replaced login command URL instead of console URL

### DIFF
--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idea-status",
-  "version": "7.108.0-next",
+  "version": "7.109.0-next",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idea-status",
-      "version": "7.108.0-next",
+      "version": "7.109.0-next",
       "license": "EPL-2.0",
       "dependencies": {
         "chokidar": "^4.0.3",

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idea-status",
-  "version": "7.108.0-next",
+  "version": "7.109.0-next",
   "description": "The app helps the user to connect a local JB Client to the in-cluster IDEA dev server over JB Gateway",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR showed login command URL instead of console page URL. It just one level up to get the login token

Ref: https://issues.redhat.com/browse/CRW-8924

https://github.com/user-attachments/assets/d8c21bf2-c61e-4636-9cab-fbf434309f62

