### PR TITLE
fix: only root.root perms for /etc/passwd (CRW-9384)

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -30,9 +30,13 @@ COPY /status-app/ /status-app/
 RUN mkdir -p /idea-server/status-app
 
 # Adjust the permissions on the entries which should be writable by group root.
-RUN for f in "${HOME}" "/etc/passwd" "/etc/group" "/status-app" "/idea-server"; do\
-        chgrp -R 0 ${f} && \
-        chmod -R g+rwX ${f}; \
+RUN for f in "${HOME}" "/etc/passwd" "/etc/group" "/status-app" "/idea-server"; do \
+        if [ "$f" != "/etc/passwd" ]; then \
+            chgrp -R 0 "$f" && \
+            chmod -R g+rwX "$f"; \
+        else \
+            chmod -R g-w "$f"; \
+        fi; \
     done
 
 # Build the status app.


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/CRW-9384

when applied `/etc/passwd` is only writable by root:
```
projects $ ls -l /etc/passwd
-rw-rw-r--. 1 root root 1156 Sep 26 09:39 /etc/passwd
```

[`entrypoint.sh`](https://github.com/che-incubator/jetbrains-ide-dev-server/blob/5f1efbacd1b2794a2dcf506f975203a366585729/build/scripts/entrypoint.sh#L18) still could add the user to `/etc/password`:
```
projects $ cat /etc/passwd
root:x:0:0:root:/root:/bin/bash
...
user:x:1008140000:0::/home/user:/bin/bash
```