### PR TITLE
Add error reporting to curl and download URL

### DIFF
--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -66,9 +66,11 @@ editor_download_url_configured=$(eval "echo \$${editor_download_url_env_name}")
 if [ -n "$editor_download_url_configured" ]; then
     ide_download_url=$editor_download_url_configured
     echo "Using editor download URL from environment variable: $ide_download_url"
+else
+    echo "Using editor download: $ide_download_url"
 fi
 
-curl -sL "$ide_download_url" | tar xzf - --strip-components=1
+curl -sSL "$ide_download_url" | tar xzf - --strip-components=1
 
 cp -r /status-app/ "$ide_server_path"
 cp /entrypoint-volume.sh "$ide_server_path"

--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -70,7 +70,7 @@ else
     echo "Using editor download: $ide_download_url"
 fi
 
-curl -sSL "$ide_download_url" | tar xzf - --strip-components=1
+curl -fsSL "$ide_download_url" | tar xzf - --strip-components=1
 
 cp -r /status-app/ "$ide_server_path"
 cp /entrypoint-volume.sh "$ide_server_path"


### PR DESCRIPTION
Adding -S to curl give us some error reporting if the download doesn't succeed, at moment we only see the error when the tar extraction fails on a broken file

Show the download URL on every download so we can see where we are trying to download from rather than only if we are trying to download from an environment variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced initialization process with improved error reporting and informational logging about IDE download configuration source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->