### PR TITLE
feat: added restart action for devfile in remote IDE (#23417)

### DIFF
--- a/che-integration-plugin/bin/test/io/github/che/devworkspace/DevWorkspacePatchTest.kt
+++ b/che-integration-plugin/bin/test/io/github/che/devworkspace/DevWorkspacePatchTest.kt
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.intellij.testFramework.LoggedErrorProcessor
+import io.kubernetes.client.custom.V1Patch
+import io.kubernetes.client.openapi.ApiException
+import io.kubernetes.client.openapi.models.V1Status
+import io.kubernetes.client.util.generic.KubernetesApiResponse
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject
+import io.kubernetes.client.util.generic.options.PatchOptions
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DevWorkspacePatchTest {
+
+    private lateinit var mockGenericApi: DynamicKubernetesApi
+    private lateinit var mapper: ObjectMapper
+    private lateinit var devWorkspacePatch: DevWorkspacePatch
+
+    private val namespace = "test-namespace"
+    private val workspaceName = "test-workspace"
+
+    @BeforeEach
+    fun setUp() {
+        mockGenericApi = mockk(relaxed = true)
+        mapper = ObjectMapper()
+        devWorkspacePatch = DevWorkspacePatch(mockGenericApi, mapper)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `#applyRestart should return true when patch succeeds`() {
+        runBlocking {
+            // given
+            mockPatchReturns(createSuccessResponse())
+
+            // when
+            val result = devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            assertThat(result).isTrue()
+
+            verify {
+                mockGenericApi.patch(
+                    namespace, workspaceName, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH, any<V1Patch>(), any<PatchOptions>()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `#applyRestart should return false when patch fails`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchReturns(createFailureResponse(403, "Forbidden"))
+
+                // when
+                val result = devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyRestart should return false when exception is thrown`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchThrows(RuntimeException("Network error"))
+
+                // when
+                val result = devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyRestart should create correct patch with restart annotation`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            assertThat(patchBody.has("metadata")).isTrue()
+            val metadata = patchBody.get("metadata")
+            assertThat(metadata.has("annotations")).isTrue()
+            val annotations = metadata.get("annotations")
+            assertThat(annotations.has("che.eclipse.org/restart-in-progress")).isTrue()
+            assertThat(annotations.get("che.eclipse.org/restart-in-progress").asText()).isEqualTo("true")
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should return true when patch succeeds`() {
+        runBlocking {
+            // given
+            val devfileContent = """
+            schemaVersion: 2.2.0
+            metadata:
+              name: my-workspace
+        """.trimIndent()
+
+            mockPatchReturns(createSuccessResponse())
+
+            // when
+            val result = devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+            // then
+            assertThat(result).isTrue()
+
+            verify {
+                mockGenericApi.patch(
+                    namespace, workspaceName, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH, any<V1Patch>(), any<PatchOptions>()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should return false when patch fails`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                val devfileContent = "test-content"
+                mockPatchReturns(createFailureResponse(404, "Not Found"))
+
+                // when
+                val result = devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should return false when exception is thrown`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                val devfileContent = "test-content"
+                mockPatchThrows(ApiException("Connection timeout"))
+
+                // when
+                val result = devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should create correct patch with devfile content`() {
+        runBlocking {
+            // given
+            val devfileContent = """
+            schemaVersion: 2.2.0
+            metadata:
+              name: my-workspace
+            components:
+              - name: tooling
+        """.trimIndent()
+
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            assertThat(patchBody.has("metadata")).isTrue()
+            val metadata = patchBody.get("metadata")
+            assertThat(metadata.has("annotations")).isTrue()
+            val annotations = metadata.get("annotations")
+            assertThat(annotations.has("che.eclipse.org/local-devfile")).isTrue()
+            assertThat(annotations.get("che.eclipse.org/local-devfile").asText()).isEqualTo(devfileContent)
+        }
+    }
+
+    @Test
+    fun `#applyRestart should use JSON_MERGE_PATCH format`() {
+        runBlocking {
+            // given
+            val capturedFormat = slot<String>()
+            val mockResponse = createSuccessResponse()
+
+            every {
+                mockGenericApi.patch(
+                    any(), any(), capture(capturedFormat), any<V1Patch>(), any<PatchOptions>()
+                )
+            } returns mockResponse
+
+            // when
+            devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            assertThat(capturedFormat.captured).isEqualTo(V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH)
+        }
+    }
+
+    @Test
+    fun `#applyRestart should use annotation key with forward slashes directly in Merge Patch`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            // In JSON Merge Patch, annotation keys with "/" are used directly as object keys
+            val annotations = patchBody.get("metadata").get("annotations")
+            assertThat(annotations.has("che.eclipse.org/restart-in-progress")).isTrue()
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should use annotation key with forward slashes directly in Merge Patch`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyDevfile(namespace, workspaceName, "content")
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            // In JSON Merge Patch, annotation keys with "/" are used directly as object keys
+            val annotations = patchBody.get("metadata").get("annotations")
+            assertThat(annotations.has("che.eclipse.org/local-devfile")).isTrue()
+        }
+    }
+
+    private fun createSuccessResponse(): KubernetesApiResponse<DynamicKubernetesObject> {
+        return mockk {
+            every { isSuccess } returns true
+        }
+    }
+
+    private fun createFailureResponse(code: Int, message: String): KubernetesApiResponse<DynamicKubernetesObject> {
+        val mockStatus = mockk<V1Status> {
+            every { this@mockk.code } returns code
+            every { this@mockk.message } returns message
+        }
+        return mockk {
+            every { isSuccess } returns false
+            every { status } returns mockStatus
+        }
+    }
+
+    private fun mockPatchReturns(response: KubernetesApiResponse<DynamicKubernetesObject>) {
+        every {
+            mockGenericApi.patch(
+                any(), any(), any(), any<V1Patch>(), any<PatchOptions>()
+            )
+        } returns response
+    }
+
+    private fun mockPatchThrows(exception: Throwable) {
+        every {
+            mockGenericApi.patch(
+                any(), any(), any(), any<V1Patch>(), any<PatchOptions>()
+            )
+        } throws exception
+    }
+
+    private fun mockPatchCaptures(capturedPatch: CapturingSlot<V1Patch>, response: KubernetesApiResponse<DynamicKubernetesObject>) {
+        every {
+            mockGenericApi.patch(
+                any(), any(), any(), capture(capturedPatch), any<PatchOptions>()
+            )
+        } returns response
+    }
+
+    @Test
+    fun `#removeDevfile should return true when patch succeeds`() {
+        runBlocking {
+            // given
+            mockPatchReturns(createSuccessResponse())
+
+            // when
+            val result = devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+            // then
+            assertThat(result).isTrue()
+
+            verify {
+                mockGenericApi.patch(
+                    namespace, workspaceName, V1Patch.PATCH_FORMAT_JSON_PATCH, any<V1Patch>(), any<PatchOptions>()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `#removeDevfile should return false when patch fails`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchReturns(createFailureResponse(404, "Not Found"))
+
+                // when
+                val result = devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#removeDevfile should return false when exception is thrown`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchThrows(ApiException("Connection timeout"))
+
+                // when
+                val result = devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#removeDevfile should create correct remove patch`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchOps = mapper.readTree(patchJson) as ArrayNode
+
+            assertThat(patchOps).hasSize(1)
+            val op = patchOps[0]
+            assertThat(op.get("op").asText()).isEqualTo("remove")
+            assertThat(op.get("path").asText()).isEqualTo("/metadata/annotations/che.eclipse.org~1local-devfile")
+            assertThat(op.has("value")).isFalse() // remove operation should not have a value
+        }
+    }
+
+}

--- a/che-integration-plugin/bin/test/io/github/che/devworkspace/DevfileTest.kt
+++ b/che-integration-plugin/bin/test/io/github/che/devworkspace/DevfileTest.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.vfs.VirtualFile
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+class DevfileTest {
+
+    // Sample valid devfile content
+    private val validDevfileContent = """
+        schemaVersion: 2.2.0
+        metadata:
+          name: my-workspace
+        components:
+          - name: tooling
+            container:
+              image: quay.io/devfile/universal-developer-image:latest
+    """.trimIndent()
+
+    // Valid devfile with schema version 2.0.0
+    private val validDevfileV20 = """
+        schemaVersion: 2.0.0
+        metadata:
+          name: workspace
+    """.trimIndent()
+
+    // Invalid devfile - schema version 1.0.0 (too old)
+    private val invalidDevfileOldSchema = """
+        schemaVersion: 1.0.0
+        metadata:
+          name: old-workspace
+    """.trimIndent()
+
+    // Invalid devfile - no metadata
+    private val invalidDevfileNoMetadata = """
+        schemaVersion: 2.2.0
+        components:
+          - name: tooling
+    """.trimIndent()
+
+    // Invalid devfile - no schemaVersion
+    private val invalidDevfileNoSchema = """
+        metadata:
+          name: workspace
+        components:
+          - name: tooling
+    """.trimIndent()
+
+    @Test
+    fun `#from returns null when file is null`() {
+        // given
+        val file: VirtualFile? = null
+
+        // when
+        val devfile = Devfile.from(file)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns null when file is directory`() {
+        // given
+        val mockFile = mockk<VirtualFile> {
+            every { isDirectory } returns true
+        }
+
+        // when
+        val devfile = Devfile.from(mockFile)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when valid content from editor`() {
+        // given
+        val mockFile = createMockFile(isDirectory = false)
+        val mockDocument = createMockDocument(validDevfileContent)
+        val documentProvider: (VirtualFile) -> Document? = { mockDocument }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNotNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when valid content from disk`() {
+        // given
+        val mockFile = createMockFileWithInputStream(validDevfileContent, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNotNull()
+    }
+
+    @Test
+    fun `#from returns null when schema version less than 2`() {
+        // given
+        val mockFile = createMockFileWithInputStream(invalidDevfileOldSchema, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns null when metadata is missing`() {
+        // given
+        val mockFile = createMockFileWithInputStream(invalidDevfileNoMetadata, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns null when schemaVersion is missing`() {
+        // given
+        val mockFile = createMockFileWithInputStream(invalidDevfileNoSchema, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when schema version is 2_0_0`() {
+        // given
+        val mockFile = createMockFileWithInputStream(validDevfileV20, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNotNull()
+    }
+
+    @Test
+    fun `#from returns null when exception is thrown`() {
+        // given
+        val mockFile = mockk<VirtualFile> {
+            every { isDirectory } returns false
+            every { inputStream } throws RuntimeException("Test exception")
+        }
+        val documentProvider: (VirtualFile) -> Document? = { throw RuntimeException("Document error") }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#getContent returns content when reading from editor`() {
+        // given
+        val mockFile = createMockFile(isDirectory = false)
+        val mockDocument = createMockDocument(validDevfileContent)
+        val documentProvider: (VirtualFile) -> Document? = { mockDocument }
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // when
+        val content = devfile?.getContent()
+
+        // then
+        assertThat(content).isEqualTo(validDevfileContent)
+    }
+
+    @Test
+    fun `#getContent returns content when reading from disk`() {
+        // given
+        val mockFile = createMockFileWithInputStream(validDevfileContent, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // when
+        val content = devfile?.getContent()
+
+        // then
+        assertThat(content).isEqualTo(validDevfileContent)
+    }
+
+    @Test
+    fun `#getContent returns null when reading fails`() {
+        // given
+        val mockFile = mockk<VirtualFile> {
+            every { isDirectory } returns false
+            every { inputStream } returns ByteArrayInputStream(validDevfileContent.toByteArray()) andThenThrows RuntimeException("Read error")
+        }
+        val documentProvider: (VirtualFile) -> Document? = { null }
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // when
+        val content = devfile?.getContent()
+
+        // then
+        assertThat(content).isNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when schema version has various formats`() {
+        // given
+        val variants = listOf(
+            "schemaVersion: 2.2.0",
+            "schemaVersion: \"2.2.0\"",
+            "schemaVersion: '2.2.0'",
+            "schemaVersion:2.2.0",
+            "schemaVersion  :  2.2.0"
+        )
+
+        // when/then
+        variants.forEach { schemaLine ->
+            val content = """
+                $schemaLine
+                metadata:
+                  name: test
+            """.trimIndent()
+
+            val mockFile = createMockFileWithInputStream(content, isDirectory = false)
+            val documentProvider: (VirtualFile) -> Document? = { null }
+
+            val devfile = Devfile.from(mockFile, documentProvider)
+
+            assertThat(devfile)
+                .withFailMessage("Failed for: $schemaLine")
+                .isNotNull()
+        }
+    }
+
+    @Test
+    fun `#from returns null when schema is beyond 8KB limit`() {
+        // given
+        val largeContent = "a".repeat(8 * 1024) + "\nschemaVersion: 2.2.0\nmetadata:\n  name: test"
+        val mockFile = createMockFileWithInputStream(largeContent, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    // Helper: Create a mock VirtualFile
+    private fun createMockFile(isDirectory: Boolean): VirtualFile {
+        return mockk {
+            every { this@mockk.isDirectory } returns isDirectory
+        }
+    }
+
+    // Helper: Create a mock Document with specific text content
+    private fun createMockDocument(text: String): Document {
+        return mockk {
+            every { this@mockk.text } returns text
+        }
+    }
+
+    // Helper: Create a mock VirtualFile with an InputStream
+    private fun createMockFileWithInputStream(content: String, isDirectory: Boolean): VirtualFile {
+        return mockk {
+            every { this@mockk.isDirectory } returns isDirectory
+            // Mock inputStream to return a fresh ByteArrayInputStream each time it's called
+            every { inputStream } answers { ByteArrayInputStream(content.toByteArray()) }
+        }
+    }
+}

--- a/che-integration-plugin/build.gradle.kts
+++ b/che-integration-plugin/build.gradle.kts
@@ -25,6 +25,23 @@ dependencies {
         // bundledPlugin("com.intellij.java")
     }
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("io.kubernetes:client-java:25.0.0") {
+        // Exclude Jackson from being bundled - IDE already provides it
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+    }
+    // Bundle only the Kotlin module classes, exclude Jackson core (already provided by IDE)    // IDE already provides Jackson core classes, we just need the Kotlin module
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2") {
+        // Exclude Jackson core dependencies - use IDE's version at runtime
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-databind")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-core")
+        exclude(group = "com.fasterxml.jackson.core", module = "jackson-annotations")
+    }
+    testImplementation("io.mockk:mockk:1.13.13")
+    testImplementation("org.assertj:assertj-core:3.27.3")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 intellijPlatform {
@@ -44,6 +61,19 @@ tasks {
     withType<JavaCompile> {
         sourceCompatibility = "21"
         targetCompatibility = "21"
+    }
+
+    // Exclude from plugin JAR - IDE already provides them
+    // Keep the Kotlin module classes (com.fasterxml.jackson.module.kotlin)
+    jar {
+        exclude("com/fasterxml/jackson/core/**")
+        exclude("com/fasterxml/jackson/databind/**")
+        exclude("com/fasterxml/jackson/annotation/**")
+    }
+
+    // Use JUnit 5 for testing
+    test {
+        useJUnitPlatform()
     }
 }
 

--- a/che-integration-plugin/src/main/kotlin/io/github/che/StartupActivity.kt
+++ b/che-integration-plugin/src/main/kotlin/io/github/che/StartupActivity.kt
@@ -17,6 +17,6 @@ import io.github.che.userActivity.UserActivityService
 
 internal class StartupActivity : ProjectActivity {
     override suspend fun execute(project: Project) {
-        project.getService<UserActivityService>(UserActivityService::class.java)
+        project.getService(UserActivityService::class.java)
     }
 }

--- a/che-integration-plugin/src/main/kotlin/io/github/che/actions/RestartWorkspaceAction.kt
+++ b/che-integration-plugin/src/main/kotlin/io/github/che/actions/RestartWorkspaceAction.kt
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.actions
+
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.MessageDialogBuilder
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import io.github.che.devworkspace.DevWorkspacePatch
+import io.github.che.devworkspace.DevWorkspaceUtils
+import io.github.che.devworkspace.Devfile
+import io.kubernetes.client.openapi.ApiClient
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+/**
+ * An action that allows restarting a DevWorkspace by applying a local devfile.
+ * The devfile is identified by content (schema: schemaVersion + metadata), so any filename
+ * is supported. The action is enabled when a project is open and the file in the editor
+ * or selected in the project tree is a devfile.
+ */
+class RestartWorkspaceAction : AnAction(), DumbAware {
+
+    /**
+     * Specifies that the update method should run on a background thread (BGT)
+     * to allow safe access to VirtualFile and PSI data structures.
+     */
+    override fun getActionUpdateThread(): ActionUpdateThread {
+        return ActionUpdateThread.BGT
+    }
+
+    /**
+     * Updates the state of the action. This method is called by the system to determine
+     * whether the action should be visible and enabled in the current context.
+     *
+     * The action is enabled only if a project is open and the file in the editor or
+     * selected in the project view is a devfile (identified by schema content).
+     *
+     * @param e The [AnActionEvent] containing information about the current context.
+     */
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val presentation = e.presentation
+
+        if (project == null) {
+            thisLogger().info("RestartWorkspaceAction: Not visible - no project")
+            presentation.isEnabledAndVisible = false
+            return
+        }
+
+        thisLogger().info("RestartWorkspaceAction: Checking for devfile in context. Place=${e.place}")
+        val devfile = findDevfile(e)
+        val isVisible = devfile != null
+
+        if (!isVisible) {
+            thisLogger().info("RestartWorkspaceAction: Not visible - no devfile found." +
+                    "\nPSI_FILE=${e.getData(CommonDataKeys.PSI_FILE)?.name}" +
+                    "\nVIRTUAL_FILE=${e.getData(CommonDataKeys.VIRTUAL_FILE)?.name}" +
+                    "\nEDITOR=${e.getData(CommonDataKeys.EDITOR) != null}")
+        } else {
+            thisLogger().info("RestartWorkspaceAction: Visible - devfile found: ${devfile.filename}")
+        }
+
+        presentation.isEnabledAndVisible = isVisible
+    }
+
+    /**
+     * Restart the DevWorkspace.
+     *
+     * Steps:
+     * 1. Identify the project and the devfile (from editor or selection, by content).
+     * 2. Read the content of the identified devfile.
+     * 3. Obtain the current workspace name, namespace, and Kubernetes API client.
+     * 4. Asynchronously apply the local devfile and restart annotation; JetBrains Gateway deletes the pod when it observes the annotation.
+     * 5. Provide user feedback in dialog in case of failure.
+     *
+     * @param e The [AnActionEvent] which contains information about the current context,
+     *          such as the project and selected files.
+     */
+    override fun actionPerformed(e: AnActionEvent) {
+        val project: Project = e.project ?: return
+
+        val devfile = findDevfile(e)
+        if (devfile == null) {
+            Messages.showErrorDialog(project, "Please select or open a devfile in the editor or project tree to restart the workspace.", "Restart Workspace")
+            return
+        }
+
+        val devfileContent = devfile.getContent()
+        if (devfileContent == null) {
+            Messages.showErrorDialog(
+                project,
+                "Failed to read devfile. Please check the file and try again.",
+                "Restart Workspace"
+            )
+            return
+        }
+
+        val workspaceName = DevWorkspaceUtils.getCurrentWorkspaceName()
+        val namespace = DevWorkspaceUtils.getCurrentWorkspaceNamespace()
+        val apiClient: ApiClient? = DevWorkspaceUtils.createApiClient()
+
+        if (workspaceName.isNullOrBlank()
+            || namespace.isNullOrBlank()
+            || apiClient == null) {
+            thisLogger().warn("Could not determine workspace name/namespace or connect to the cluster." +
+                    "workspaceName: $workspaceName, namespace: $namespace, apiClient: $apiClient")
+            Messages.showErrorDialog(project,
+                "Could not determine workspace name/namespace or connect to the cluster.",
+                "Restart Workspace")
+            return
+        }
+
+        val restart = MessageDialogBuilder
+            .yesNo(
+                "Restart Workspace",
+                "Are you sure you want to restart the workspace? This will apply the local devfile."
+            )
+            .yesText("Restart Workspace")
+            .noText("Cancel")
+            .ask(e.getData(PlatformDataKeys.CONTEXT_COMPONENT))
+
+        if (!restart) {
+            return
+        }
+
+        restart(apiClient, namespace, workspaceName, devfileContent, project)
+    }
+
+    private fun restart(
+        apiClient: ApiClient,
+        namespace: String,
+        workspaceName: String,
+        devfileContent: String,
+        project: Project
+    ) {
+        ApplicationManager.getApplication().executeOnPooledThread {
+            runBlocking {
+                val patch = DevWorkspacePatch(apiClient)
+
+                val modified = patch.applyDevfile(namespace, workspaceName, devfileContent)
+                if (!modified) {
+                    withContext(Dispatchers.Main) {
+                        Messages.showErrorDialog(
+                            project,
+                            "Failed to apply local devfile to DevWorkspace.",
+                            "Restart Workspace"
+                        )
+                    }
+                    return@runBlocking
+                }
+
+                val applied = patch.applyRestart(namespace, workspaceName)
+                if (!applied) {
+                    // Rollback: remove the local devfile annotation to maintain atomicity
+                    thisLogger().info("Rolling back devfile annotation for $namespace/$workspaceName due to restart annotation failure")
+                    val rollbackSuccess = patch.removeDevfile(namespace, workspaceName)
+                    if (rollbackSuccess) {
+                        thisLogger().info("Successfully rolled back devfile annotation for $namespace/$workspaceName")
+                    } else {
+                        thisLogger().error("Failed to rollback devfile annotation for $namespace/$workspaceName - workspace may be in inconsistent state")
+                    }
+
+                    withContext(Dispatchers.Main) {
+                        thisLogger().warn("Failed to annotate DevWorkspace $namespace/$workspaceName for restart. Aborting.")
+                        Messages.showErrorDialog(
+                            project,
+                            "Could not restart workspace $namespace/$workspaceName. Could not annotate for restart",
+                            "Restart Workspace"
+                        )
+                    }
+                    return@runBlocking
+                }
+
+                withContext(Dispatchers.Main) {
+                    Messages.showInfoMessage(
+                        project,
+                        "Workspace restart initiated successfully. The workspace will restart with the updated devfile.",
+                        "Restart Workspace"
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * Retrieves a devfile from the current action event context by inspecting the file
+     * currently open in the editor or selected in the project tree. A file is considered
+     * a devfile if its content matches the devfile schema (presence of `schemaVersion`
+     * and `metadata`), so any filename is supported (e.g. `devfile.yaml`, `.devfile.yaml`,
+     * or custom names like `my-workspace.yaml`).
+     *
+     * Checks multiple sources in order:
+     * 1. The PSI file currently being edited (for editor context menu)
+     * 2. The file associated with the current editor document
+     * 3. The selected file(s) in project view (VIRTUAL_FILE or VIRTUAL_FILE_ARRAY)
+     * 4. Selected items from PlatformDataKeys (for project view)
+     *
+     * @param e The [AnActionEvent] providing access to the current editor and project selection data.
+     * @return The [io.github.che.devworkspace.Devfile] instance if found, otherwise `null`.
+     */
+    private fun findDevfile(e: AnActionEvent): Devfile? {
+        thisLogger().debug("findDevfile: Checking PSI_FILE...")
+        Devfile.from(getFromPsiFile(e))?.let {
+            thisLogger().debug("findDevfile: Found devfile from PSI_FILE")
+            return it
+        }
+
+        thisLogger().debug("findDevfile: Checking EDITOR...")
+        Devfile.from(getFromEditor(e))?.let {
+            thisLogger().debug("findDevfile: Found devfile from EDITOR")
+            return it
+        }
+
+        thisLogger().debug("findDevfile: Checking VIRTUAL_FILE...")
+        getFromVirtualFile(e).firstNotNullOfOrNull { Devfile.from(it) }?.let {
+            thisLogger().debug("findDevfile: Found devfile from VIRTUAL_FILE")
+            return it
+        }
+
+        thisLogger().info("findDevfile: No devfile found in any source")
+        return null
+    }
+
+    private fun getFromVirtualFile(e: AnActionEvent): Sequence<VirtualFile> {
+        val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        if (virtualFile != null && !virtualFile.isDirectory) {
+            thisLogger().debug("getFromVirtualFile: Found single VIRTUAL_FILE: ${virtualFile.name}")
+            return sequenceOf(virtualFile)
+        }
+
+        val array = e.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY).orEmpty()
+        val fromArray = array.asSequence().filter { !it.isDirectory }
+        if (fromArray.any()) {
+            thisLogger().debug("getFromVirtualFile: Found files from VIRTUAL_FILE_ARRAY: ${fromArray.joinToString { it.name }}")
+            return fromArray
+        }
+
+        val selectedItems = e.getData(PlatformDataKeys.SELECTED_ITEMS) ?: emptyArray<Any>()
+        thisLogger().debug("getFromVirtualFile: Checking SELECTED_ITEMS, count=${selectedItems.size}")
+        return selectedItems.asSequence().mapNotNull { item ->
+            when (item) {
+                is PsiFile -> item.virtualFile.also {
+                    thisLogger().info("getFromVirtualFile: SELECTED_ITEMS contains PsiFile: ${it?.name}")
+                }
+                is VirtualFile -> item.also {
+                    thisLogger().debug("getFromVirtualFile: SELECTED_ITEMS contains VirtualFile: ${it.name}")
+                }
+                else -> {
+                    thisLogger().debug("getFromVirtualFile: SELECTED_ITEMS contains unknown type: ${item.javaClass.simpleName}")
+                    null
+                }
+            }
+        }
+            .filter { !it.isDirectory }
+            .map { it }
+    }
+
+    private fun getFromPsiFile(e: AnActionEvent): VirtualFile? {
+        val psiFile: PsiFile? = e.getData(CommonDataKeys.PSI_FILE)
+        val vf = psiFile?.virtualFile
+        if (vf != null && !vf.isDirectory) {
+            thisLogger().info("getFromPsiFile: Found file: ${vf.name}")
+            return vf
+        } else if (vf != null) {
+            thisLogger().debug("getFromPsiFile: PSI_FILE is directory: ${vf.name}")
+        } else {
+            thisLogger().debug("getFromPsiFile: No PSI_FILE or virtualFile is null")
+        }
+        return null
+    }
+
+    private fun getFromEditor(e: AnActionEvent): VirtualFile? {
+        val editor: Editor? = e.getData(CommonDataKeys.EDITOR)
+        if (editor == null) {
+            thisLogger().debug("getFromEditor: No EDITOR in context")
+            return null
+        }
+
+        val vf = editor.document.let { doc ->
+            FileDocumentManager.getInstance().getFile(doc)
+        }?.takeIf { !it.isDirectory }
+
+        if (vf != null) {
+            thisLogger().debug("getFromEditor: Found file: ${vf.name}")
+        } else {
+            thisLogger().debug("getFromEditor: EDITOR present but no valid file found")
+        }
+        return vf
+    }
+}

--- a/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/DevWorkspacePatch.kt
+++ b/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/DevWorkspacePatch.kt
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import com.fasterxml.jackson.databind.Module
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.intellij.openapi.diagnostic.thisLogger
+import io.kubernetes.client.custom.V1Patch
+import io.kubernetes.client.openapi.ApiClient
+import io.kubernetes.client.openapi.ApiException
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi
+import io.kubernetes.client.util.generic.options.PatchOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Utility class for patching DevWorkspace resources.
+ *
+ * This class handles applying local devfiles, setting restart annotations, and other
+ * patch operations on DevWorkspace resources. The restart marker annotation
+ * (`che.eclipse.org/restart-in-progress`) signals the JetBrains Gateway plugin to roll
+ * the workspace pod. The Gateway watches the DevWorkspace for this annotation and deletes
+ * the pod; on client close it also avoids stopping the DevWorkspace while this marker is set.
+ *
+ * - CRD group: workspace.devfile.io
+ * - version: v1alpha2
+ * - resource: devworkspaces
+ *
+ * @param genericApi the kubernetes api to operate on
+ * @param mapper the mapper to create json with
+ */
+    class DevWorkspacePatch internal constructor(
+    private val genericApi: DynamicKubernetesApi,
+    private val mapper: ObjectMapper
+) {
+
+    /**
+     * @param apiClient kubernetes client to use in the dynamic kubernetes api
+     */
+    constructor(apiClient: ApiClient) : this(
+        DynamicKubernetesApi(API_GROUP, API_VERSION, RESOURCE_PLURAL, apiClient),
+        createObjectMapper()
+    )
+
+    companion object {
+        private const val API_GROUP = "workspace.devfile.io"
+        private const val API_VERSION = "v1alpha2"
+        private const val RESOURCE_PLURAL = "devworkspaces"
+        private const val ANNOTATION_KEY = "che.eclipse.org/restart-in-progress"
+        private const val ANNOTATION_VALUE = "true"
+
+        /**
+         * Creates an ObjectMapper using the IDE's Jackson classes and registers the Kotlin module.
+         * This avoids classloader conflicts by using IDE's Jackson core classes.
+         *
+         * @return [ObjectMapper]
+         */
+        private fun createObjectMapper(): ObjectMapper {
+            val mapper = ObjectMapper()
+            try {
+                // avoid jackson instantiation issues
+                val kotlinModuleClass = Class.forName("com.fasterxml.jackson.module.kotlin.KotlinModule")
+                val kotlinModule = kotlinModuleClass.getDeclaredConstructor().newInstance()
+                mapper.registerModule(kotlinModule as Module)
+            } catch (e: Exception) {
+                thisLogger().warn("Failed to register Kotlin module, continuing without it", e)
+            }
+            return mapper
+        }
+
+        /**
+         * Escapes a string for use in a JSON Pointer path according to RFC 6901.
+         * - "~" is replaced with "~0"
+         * - "/" is replaced with "~1"
+         *
+         * @param key The string to escape
+         * @return The escaped string safe for use in JSON Pointer paths
+         */
+        private fun escapeJsonPointer(key: String): String {
+            return key.replace("~", "~0").replace("/", "~1")
+        }
+    }
+
+    /**
+     * Adds the restart marker annotation to the specified DevWorkspace resource.
+     * This signals the Gateway plugin to restart the workspace.
+     *
+     * Uses JSON Merge Patch (RFC 7386) which automatically creates the annotations map if missing.
+     *
+     * @param name The name of the DevWorkspace.
+     * @param namespace The namespace of the DevWorkspace.
+     * @return `true` if the annotation was successfully added, `false` otherwise.
+     */
+    suspend fun applyRestart(namespace: String, name: String): Boolean {
+        return try {
+            withContext(Dispatchers.IO) {
+                val body = mapOf(
+                    "metadata" to mapOf(
+                        "annotations" to mapOf(
+                            ANNOTATION_KEY to ANNOTATION_VALUE
+                        )
+                    )
+                )
+
+                thisLogger().info("Adding annotation $ANNOTATION_KEY to $namespace/$name")
+                patch(namespace, name, body, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH)
+            }
+            true
+        } catch (t: Throwable) {
+            thisLogger().error("Failed to add restart DevWorkspace annotation to $namespace/$name", t)
+            false
+        }
+    }
+
+    /**
+     * Applies the given devfile content to the DevWorkspace custom resource by patching
+     * the `metadata.annotations["che.eclipse.org/local-devfile"]` field.
+     *
+     * Uses JSON Merge Patch (RFC 7386) which automatically creates the annotations map if missing.
+     *
+     * This operation runs on the IO dispatcher.
+     *
+     * @param namespace The namespace of the DevWorkspace.
+     * @param name The name of the DevWorkspace.
+     * @param devfileContent The content of the devfile to be applied as an annotation.
+     * @return `true` if the devfile was successfully applied, `false` otherwise.
+     */
+    suspend fun applyDevfile(namespace: String, name: String, devfileContent: String): Boolean {
+        return try {
+            withContext(Dispatchers.IO) {
+                val annotationKey = "che.eclipse.org/local-devfile"
+                val body = mapOf(
+                    "metadata" to mapOf(
+                        "annotations" to mapOf(
+                            annotationKey to devfileContent
+                        )
+                    )
+                )
+
+                thisLogger().info("Adding annotation $annotationKey to $namespace/$name")
+                patch(namespace, name, body, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH)
+            }
+            true
+        } catch (t: Throwable) {
+            thisLogger().error("Failed to apply local devfile to $namespace/$name", t)
+            false
+        }
+    }
+
+    /**
+     * Removes the local devfile annotation from the DevWorkspace custom resource.
+     * This is used to roll back a devfile application when the restart annotation fails.
+     *
+     * Uses JSON Patch (RFC 6902) for explicit removal.
+     *
+     * This operation runs on the IO dispatcher.
+     *
+     * @param namespace The namespace of the DevWorkspace.
+     * @param name The name of the DevWorkspace.
+     * @return `true` if the annotation was successfully removed, `false` otherwise.
+     */
+    suspend fun removeDevfile(namespace: String, name: String): Boolean {
+        return try {
+            withContext(Dispatchers.IO) {
+                val annotationKey = "che.eclipse.org/local-devfile"
+                val path = "/metadata/annotations/${escapeJsonPointer(annotationKey)}"
+
+                val ops = listOf(
+                    mapOf(
+                        "op" to "remove",
+                        "path" to path
+                    )
+                )
+
+                thisLogger().info("Removing annotation $annotationKey from $namespace/$name")
+                patch(namespace, name, ops, V1Patch.PATCH_FORMAT_JSON_PATCH)
+            }
+            true
+        } catch (t: Throwable) {
+            thisLogger().error("Failed to remove local devfile annotation from $namespace/$name", t)
+            false
+        }
+    }
+
+    /**
+     * Performs a patch operation on a DevWorkspace custom resource using GenericKubernetesApi.
+     *
+     * @param namespace The namespace of the DevWorkspace.
+     * @param name The name of the DevWorkspace.
+     * @param patchBody The patch body, which can be a String or any object that can be serialized to JSON.
+     * @param patchFormat The patch format (JSON Patch, Strategic Merge Patch, etc.)
+     * @throws ApiException if the Kubernetes API call fails.
+     * @throws Throwable for any other unexpected errors during the patching process.
+     */
+    @Throws(ApiException::class)
+    private fun patch(namespace: String, name: String, patchBody: Any, patchFormat: String) {
+        try {
+            val patchString = toString(patchBody)
+            val v1Patch = V1Patch(patchString)
+
+            thisLogger().info("Patching DevWorkspace $namespace/$name using $patchFormat")
+            val response = genericApi.patch(
+                namespace,
+                name,
+                patchFormat,
+                v1Patch,
+                PatchOptions()
+            )
+
+            if (!response.isSuccess) {
+                val status = response.status
+                val message = status?.message ?: "Unknown error"
+                val code = status?.code ?: 0
+                throw ApiException(
+                    "Could not patch $namespace/$name: $message (code: $code)",
+                    code,
+                    null,
+                    null
+                )
+            }
+
+            thisLogger().info("Successfully patched DevWorkspace $namespace/$name")
+        } catch (t: Throwable) {
+            thisLogger().error("Could not patch $namespace/$name", t)
+            throw t
+        }
+    }
+
+    private fun toString(body: Any): String? {
+        return when (body) {
+            is String -> body
+            else -> mapper.writeValueAsString(body)
+        }
+    }
+}

--- a/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/DevWorkspaceUtils.kt
+++ b/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/DevWorkspaceUtils.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import com.intellij.openapi.diagnostic.thisLogger
+import io.kubernetes.client.util.Config
+import io.kubernetes.client.openapi.ApiClient
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Provides utilities for obtaining Kubernetes API client and DevWorkspace context information.
+ * This object is responsible for resolving the Kubernetes API client, as well as the
+ * current DevWorkspace name and namespace, typically from environment variables.
+ */
+object DevWorkspaceUtils {
+    /**
+     * Attempts to create a Kubernetes [ApiClient] by checking the following sources in order:
+     * 1. The `KUBECONFIG` environment variable.
+     * 2. The default kubeconfig file located at `~/.kube/config`.
+     * 3. The Kubernetes Java client's default client configuration.
+     *
+     * @return An initialized [ApiClient] if successful, or `null` if an API client
+     *         cannot be created or an error occurs during the process.
+     */
+    fun createApiClient(): ApiClient? {
+        try {
+            val kubeconfigPath = getKubeConfigPath()
+
+            return kubeconfigPath?.takeIf { Files.exists(Paths.get(it)) }
+                ?.let { Config.fromConfig(it) }
+                ?: Config.defaultClient()
+        } catch (e: Throwable) {
+            thisLogger().warn("Could not load Kubernetes client", e)
+            return null
+        }
+    }
+
+    private fun getKubeConfigPath(): String? {
+        return System.getenv("KUBECONFIG")
+            ?: File(System.getProperty("user.home"), ".kube/config")
+                .takeIf { it.exists() }?.absolutePath
+    }
+
+    /**
+     * Resolves the current DevWorkspace name for the project.
+     *
+     * Retrieves the workspace name from the `DEVWORKSPACE_NAME`
+     * environment variable.
+     *
+     * @return The name of the current DevWorkspace as a [String], or `null` if not found.
+     */
+    fun getCurrentWorkspaceName(): String? {
+        return System.getenv("DEVWORKSPACE_NAME")
+    }
+
+    /**
+     * Resolves the current namespace for the project's DevWorkspace.
+     *
+     * Retrieves the namespace from the `DEVWORKSPACE_NAMESPACE`
+     * environment variable.
+     *
+     * @return The namespace of the current DevWorkspace as a [String], or `null` if not found.
+     */
+    fun getCurrentWorkspaceNamespace(): String? {
+        return System.getenv("DEVWORKSPACE_NAMESPACE")
+    }
+}

--- a/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/DevWorkspaceUtils.kt
+++ b/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/DevWorkspaceUtils.kt
@@ -24,31 +24,54 @@ import java.nio.file.Paths
  * current DevWorkspace name and namespace, typically from environment variables.
  */
 object DevWorkspaceUtils {
+
+    private val defaultEnvProvider: (String) -> String? = System::getenv
+
+    private val defaultHomeProvider: () -> String = { System.getProperty("user.home") }
+
+    private val defaultClientFactory: (String?) -> ApiClient = { path ->
+        if (path != null) {
+            Config.fromConfig(path)
+        } else {
+            Config.defaultClient()
+        }
+    }
+
     /**
      * Attempts to create a Kubernetes [ApiClient] by checking the following sources in order:
      * 1. The `KUBECONFIG` environment variable.
      * 2. The default kubeconfig file located at `~/.kube/config`.
      * 3. The Kubernetes Java client's default client configuration.
      *
+     * @param envProvider Function to retrieve environment variables (defaults to System::getenv)
+     * @param homeProvider Function to retrieve user home directory (defaults to user.home system property)
+     * @param clientFactory Function to create ApiClient from kubeconfig path (defaults to Config.fromConfig/defaultClient)
      * @return An initialized [ApiClient] if successful, or `null` if an API client
      *         cannot be created or an error occurs during the process.
      */
-    fun createApiClient(): ApiClient? {
+    fun createApiClient(
+        envProvider: (String) -> String? = defaultEnvProvider,
+        homeProvider: () -> String = defaultHomeProvider,
+        clientFactory: (String?) -> ApiClient = defaultClientFactory
+    ): ApiClient? {
         try {
-            val kubeconfigPath = getKubeConfigPath()
+            val kubeconfigPath = getKubeConfigPath(envProvider, homeProvider)
 
             return kubeconfigPath?.takeIf { Files.exists(Paths.get(it)) }
-                ?.let { Config.fromConfig(it) }
-                ?: Config.defaultClient()
+                ?.let { clientFactory(it) }
+                ?: clientFactory(null)
         } catch (e: Throwable) {
             thisLogger().warn("Could not load Kubernetes client", e)
             return null
         }
     }
 
-    private fun getKubeConfigPath(): String? {
-        return System.getenv("KUBECONFIG")
-            ?: File(System.getProperty("user.home"), ".kube/config")
+    private fun getKubeConfigPath(
+        envProvider: (String) -> String?,
+        homeProvider: () -> String
+    ): String? {
+        return envProvider("KUBECONFIG")
+            ?: File(homeProvider(), ".kube/config")
                 .takeIf { it.exists() }?.absolutePath
     }
 
@@ -58,10 +81,13 @@ object DevWorkspaceUtils {
      * Retrieves the workspace name from the `DEVWORKSPACE_NAME`
      * environment variable.
      *
+     * @param envProvider Function to retrieve environment variables (defaults to System::getenv)
      * @return The name of the current DevWorkspace as a [String], or `null` if not found.
      */
-    fun getCurrentWorkspaceName(): String? {
-        return System.getenv("DEVWORKSPACE_NAME")
+    fun getCurrentWorkspaceName(
+        envProvider: (String) -> String? = defaultEnvProvider
+    ): String? {
+        return envProvider("DEVWORKSPACE_NAME")
     }
 
     /**
@@ -70,9 +96,12 @@ object DevWorkspaceUtils {
      * Retrieves the namespace from the `DEVWORKSPACE_NAMESPACE`
      * environment variable.
      *
+     * @param envProvider Function to retrieve environment variables (defaults to System::getenv)
      * @return The namespace of the current DevWorkspace as a [String], or `null` if not found.
      */
-    fun getCurrentWorkspaceNamespace(): String? {
-        return System.getenv("DEVWORKSPACE_NAMESPACE")
+    fun getCurrentWorkspaceNamespace(
+        envProvider: (String) -> String? = defaultEnvProvider
+    ): String? {
+        return envProvider("DEVWORKSPACE_NAMESPACE")
     }
 }

--- a/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/Devfile.kt
+++ b/che-integration-plugin/src/main/kotlin/io/github/che/devworkspace/Devfile.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.vfs.VirtualFile
+import java.nio.charset.StandardCharsets
+import java.util.regex.Pattern
+
+/**
+ * Represents a devfile with methods to validate and read its content.
+ */
+class Devfile internal constructor(
+    private val file: VirtualFile,
+    private val documentProvider: (VirtualFile) -> Document? = {
+        FileDocumentManager.getInstance().getCachedDocument(it)
+    }
+) {
+
+    companion object {
+        private const val DETECTION_LIMIT_BYTES = 8 * 1024
+
+        private val SCHEMA_VERSION_PATTERN = Pattern.compile(
+            "schemaVersion\\s*:\\s*[\"']?(\\d+\\.\\d+(?:\\.\\d+)?)"
+        )
+
+        /**
+         * Creates a Devfile instance from a VirtualFile if the file is a valid devfile.
+         * A file is considered a devfile if its content matches the devfile schema
+         * (presence of `schemaVersion` >= 2 and `metadata`).
+         *
+         * Works with any filename (e.g. devfile.yaml, .devfile.yaml, my-workspace.yaml).
+         * Only the first [DETECTION_LIMIT_BYTES] bytes are read for validation.
+         *
+         * @param file The virtual file to check and wrap.
+         * @param documentProvider Lambda to provide cached documents (for testing).
+         * @return A [Devfile] instance if the file is a valid devfile, otherwise `null`.
+         */
+        fun from(
+            file: VirtualFile?,
+            documentProvider: (VirtualFile) -> Document? = {
+                FileDocumentManager.getInstance().getCachedDocument(it)
+            }
+        ): Devfile? {
+            return if (file == null || file.isDirectory) {
+                null
+            }
+            else if (isDevfile(file, documentProvider)) {
+                Devfile(file, documentProvider)
+            } else {
+                null
+            }
+        }
+
+        /**
+         * Returns `true` if the file content looks like a devfile. Determined using:
+         * * has "schemaVersion"
+         * * schemaVersion >= 2
+         * * has "metadata".
+         *
+         * Only the first [DETECTION_LIMIT_BYTES] bytes are read.
+         * Works with any filename (e.g. devfile.yaml, .devfile.yaml, my-workspace.yaml).
+         * Reads from the editor buffer if the file is open (includes unsaved changes),
+         * otherwise reads from disk.
+         *
+         * @param file The virtual file to check (must be a regular file, not a directory).
+         * @param documentProvider Lambda to provide cached documents.
+         * @return true if the content matches devfile schema, false otherwise.
+         */
+        private fun isDevfile(
+            file: VirtualFile,
+            documentProvider: (VirtualFile) -> Document?
+        ): Boolean {
+            if (file.isDirectory) return false
+            val content = try {
+                val document = documentProvider(file)
+                document?.text?.take(DETECTION_LIMIT_BYTES) // in editor
+                    ?: file.inputStream.use {
+                        it.readNBytes(DETECTION_LIMIT_BYTES).toString(StandardCharsets.UTF_8)
+                    } // on disk
+            } catch (_: Exception) {
+                return false
+            }
+            if (!content.contains("metadata")) return false
+            val schemaMatcher = SCHEMA_VERSION_PATTERN.matcher(content)
+            if (!schemaMatcher.find()) return false
+            val major = schemaMatcher.group(1).substringBefore('.').toIntOrNull() ?: return false
+            return major >= 2
+        }
+    }
+
+    val filename: String
+        get() {
+            return file.name
+        }
+
+    /**
+     * Reads and returns the content of the devfile as a String.
+     * Reads from the editor buffer if the file is open (includes unsaved changes),
+     * otherwise reads from disk.
+     *
+     * @return The devfile content, or `null` if reading fails.
+     */
+    fun getContent(): String? {
+        return try {
+            val document = documentProvider(file)
+            document?.text // file in editor
+                ?: file.inputStream.use {
+                    it.readBytes().toString(StandardCharsets.UTF_8)
+                } // file on disk
+        } catch (t: Throwable) {
+            thisLogger().warn("Failed to read devfile: ${t.message}", t)
+            null
+        }
+    }
+}

--- a/che-integration-plugin/src/main/kotlin/io/github/che/userActivity/UserActivityService.kt
+++ b/che-integration-plugin/src/main/kotlin/io/github/che/userActivity/UserActivityService.kt
@@ -11,6 +11,7 @@
  */
 package io.github.che.userActivity
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.event.CaretEvent
@@ -24,7 +25,11 @@ import java.net.URL
 import javax.swing.Timer
 
 @Service(Service.Level.PROJECT)
-class UserActivityService {
+class UserActivityService : Disposable {
+
+    private val caretListener = object : CaretListener {
+        override fun caretPositionChanged(event: CaretEvent) = updateLastActivityTime()
+    }
 
     private var lastActivityTime: Long = System.currentTimeMillis()
 
@@ -50,9 +55,14 @@ class UserActivityService {
 
     private fun setupActivityListeners() {
         val eventMulticaster = EditorFactory.getInstance().eventMulticaster
-        eventMulticaster.addCaretListener(object : CaretListener {
-            override fun caretPositionChanged(event: CaretEvent) = updateLastActivityTime()
-        }) {}
+        eventMulticaster.addCaretListener(caretListener, this)
+    }
+    
+    override fun dispose() {
+        timer.stop()
+        EditorFactory.getInstance().eventMulticaster.removeCaretListener(caretListener)
+        httpClient.dispatcher.executorService.shutdown()
+        httpClient.connectionPool.evictAll()
     }
 
     private fun updateLastActivityTime() {

--- a/che-integration-plugin/src/main/resources/META-INF/plugin.xml
+++ b/che-integration-plugin/src/main/resources/META-INF/plugin.xml
@@ -25,4 +25,18 @@
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="io.github.che.StartupActivity"/>
     </extensions>
+
+    <actions>
+        <action
+                id="io.github.che.action.RestartWorkspace"
+                class="io.github.che.actions.RestartWorkspaceAction"
+                text="Restart Workspace (Devfile)"
+                description="Restart the current workspace based on local devfile.yaml">
+            <!-- editor context menu -->
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <!-- project view context menu -->
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
+        </action>
+    </actions>
+
 </idea-plugin>

--- a/che-integration-plugin/src/test/kotlin/io/github/che/actions/RestartWorkspaceActionTest.kt
+++ b/che-integration-plugin/src/test/kotlin/io/github/che/actions/RestartWorkspaceActionTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.actions
+
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.PlatformDataKeys
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+class RestartWorkspaceActionTest {
+
+    private val action = RestartWorkspaceAction()
+
+    private val validDevfileContent = """
+        schemaVersion: 2.2.0
+        metadata:
+          name: my-workspace
+        components:
+          - name: tooling
+    """.trimIndent()
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ===== update() =====
+
+    @Test
+    fun `#update disables action when project is null`() {
+        // given
+        val (event, presentation) = createMockEvent(project = null)
+
+        // when
+        action.update(event)
+
+        // then
+        verify { presentation.isEnabledAndVisible = false }
+    }
+
+    @Test
+    fun `#update hides action when no devfile is in context`() {
+        // given
+        val (event, presentation) = createMockEvent()
+        every { event.getData(CommonDataKeys.PSI_FILE) } returns null
+        every { event.getData(CommonDataKeys.EDITOR) } returns null
+        every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns null
+        // relaxed mock returns Object (not null) for generic getData due to type erasure — explicit nulls required
+        every { event.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY) } returns null
+        every { event.getData(PlatformDataKeys.SELECTED_ITEMS) } returns null
+
+        // when
+        action.update(event)
+
+        // then
+        verify { presentation.isEnabledAndVisible = false }
+    }
+
+    @Test
+    fun `#update shows action when PSI_FILE is a valid devfile`() {
+        // given
+        val mockVirtualFile = createMockVirtualFile(validDevfileContent)
+        val mockPsiFile = mockk<PsiFile>()
+        every { mockPsiFile.virtualFile } returns mockVirtualFile
+
+        val (event, presentation) = createMockEvent()
+        every { event.getData(CommonDataKeys.PSI_FILE) } returns mockPsiFile
+        createMockFileDocumentManager(mockVirtualFile)
+
+        // when
+        action.update(event)
+
+        // then
+        verify { presentation.isEnabledAndVisible = true }
+    }
+
+    @Test
+    fun `#update shows action when VIRTUAL_FILE is a valid devfile`() {
+        // given
+        val mockVirtualFile = createMockVirtualFile(validDevfileContent)
+
+        val (event, presentation) = createMockEvent()
+        every { event.getData(CommonDataKeys.PSI_FILE) } returns null
+        every { event.getData(CommonDataKeys.EDITOR) } returns null
+        every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns mockVirtualFile
+        createMockFileDocumentManager(mockVirtualFile)
+
+        // when
+        action.update(event)
+
+        // then
+        verify { presentation.isEnabledAndVisible = true }
+    }
+
+    @Test
+    fun `#update hides action when VIRTUAL_FILE is not a devfile`() {
+        // given
+        val mockVirtualFile = createMockVirtualFile("just some yaml content without schemaVersion")
+
+        val (event, presentation) = createMockEvent()
+        every { event.getData(CommonDataKeys.PSI_FILE) } returns null
+        every { event.getData(CommonDataKeys.EDITOR) } returns null
+        every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns mockVirtualFile
+        createMockFileDocumentManager(mockVirtualFile)
+
+        // when
+        action.update(event)
+
+        // then
+        verify { presentation.isEnabledAndVisible = false }
+    }
+
+    @Test
+    fun `#update hides action when VIRTUAL_FILE is a directory`() {
+        // given
+        // relaxed = true so getName() is available for the debug log in update()
+        val mockDirectory = mockk<VirtualFile>(relaxed = true)
+        every { mockDirectory.isDirectory } returns true
+
+        val (event, presentation) = createMockEvent()
+        every { event.getData(CommonDataKeys.PSI_FILE) } returns null
+        every { event.getData(CommonDataKeys.EDITOR) } returns null
+        every { event.getData(CommonDataKeys.VIRTUAL_FILE) } returns mockDirectory
+        // directory falls through to VIRTUAL_FILE_ARRAY and SELECTED_ITEMS; relaxed mock returns Object, not null
+        every { event.getData(CommonDataKeys.VIRTUAL_FILE_ARRAY) } returns null
+        every { event.getData(PlatformDataKeys.SELECTED_ITEMS) } returns null
+
+        // when
+        action.update(event)
+
+        // then
+        verify { presentation.isEnabledAndVisible = false }
+    }
+
+    /**
+     * Creates a mock [AnActionEvent] paired with its [Presentation].
+     * The event is relaxed so unspecified [AnActionEvent.getData] calls return null.
+     * Note: getData calls returning array types must still be mocked explicitly — the relaxed mock
+     * returns Object (not null) for generic methods due to type erasure, causing a ClassCastException.
+     */
+    private fun createMockEvent(project: Project? = mockk()): Pair<AnActionEvent, Presentation> {
+        val presentation = mockk<Presentation>(relaxed = true)
+        val event = mockk<AnActionEvent>(relaxed = true)
+        every { event.project } returns project
+        every { event.presentation } returns presentation
+        return event to presentation
+    }
+
+    /**
+     * Stubs [FileDocumentManager] so that [FileDocumentManager.getCachedDocument] returns null
+     * for each given file, causing [io.github.che.devworkspace.Devfile] to fall back to reading
+     * content from disk (i.e. from the VirtualFile's inputStream).
+     */
+    private fun createMockFileDocumentManager(vararg files: VirtualFile) {
+        mockkStatic(FileDocumentManager::class)
+        val mock = mockk<FileDocumentManager>()
+        every { FileDocumentManager.getInstance() } returns mock
+        files.forEach { every { mock.getCachedDocument(it) } returns null }
+    }
+
+    /**
+     * Creates a mock [VirtualFile] backed by the given [content].
+     * relaxed = true so getName() is available when it appears in debug log output.
+     */
+    private fun createMockVirtualFile(content: String): VirtualFile {
+        return mockk(relaxed = true) {
+            every { isDirectory } returns false
+            every { inputStream } answers { ByteArrayInputStream(content.toByteArray()) }
+        }
+    }
+}

--- a/che-integration-plugin/src/test/kotlin/io/github/che/devworkspace/DevWorkspacePatchTest.kt
+++ b/che-integration-plugin/src/test/kotlin/io/github/che/devworkspace/DevWorkspacePatchTest.kt
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.intellij.testFramework.LoggedErrorProcessor
+import io.kubernetes.client.custom.V1Patch
+import io.kubernetes.client.openapi.ApiException
+import io.kubernetes.client.openapi.models.V1Status
+import io.kubernetes.client.util.generic.KubernetesApiResponse
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesApi
+import io.kubernetes.client.util.generic.dynamic.DynamicKubernetesObject
+import io.kubernetes.client.util.generic.options.PatchOptions
+import io.mockk.*
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class DevWorkspacePatchTest {
+
+    private lateinit var mockGenericApi: DynamicKubernetesApi
+    private lateinit var mapper: ObjectMapper
+    private lateinit var devWorkspacePatch: DevWorkspacePatch
+
+    private val namespace = "test-namespace"
+    private val workspaceName = "test-workspace"
+
+    @BeforeEach
+    fun setUp() {
+        mockGenericApi = mockk(relaxed = true)
+        mapper = ObjectMapper()
+        devWorkspacePatch = DevWorkspacePatch(mockGenericApi, mapper)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `#applyRestart should return true when patch succeeds`() {
+        runBlocking {
+            // given
+            mockPatchReturns(createSuccessResponse())
+
+            // when
+            val result = devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            assertThat(result).isTrue()
+
+            verify {
+                mockGenericApi.patch(
+                    namespace, workspaceName, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH, any<V1Patch>(), any<PatchOptions>()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `#applyRestart should return false when patch fails`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchReturns(createFailureResponse(403, "Forbidden"))
+
+                // when
+                val result = devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyRestart should return false when exception is thrown`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchThrows(RuntimeException("Network error"))
+
+                // when
+                val result = devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyRestart should create correct patch with restart annotation`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            assertThat(patchBody.has("metadata")).isTrue()
+            val metadata = patchBody.get("metadata")
+            assertThat(metadata.has("annotations")).isTrue()
+            val annotations = metadata.get("annotations")
+            assertThat(annotations.has("che.eclipse.org/restart-in-progress")).isTrue()
+            assertThat(annotations.get("che.eclipse.org/restart-in-progress").asText()).isEqualTo("true")
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should return true when patch succeeds`() {
+        runBlocking {
+            // given
+            val devfileContent = """
+            schemaVersion: 2.2.0
+            metadata:
+              name: my-workspace
+        """.trimIndent()
+
+            mockPatchReturns(createSuccessResponse())
+
+            // when
+            val result = devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+            // then
+            assertThat(result).isTrue()
+
+            verify {
+                mockGenericApi.patch(
+                    namespace, workspaceName, V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH, any<V1Patch>(), any<PatchOptions>()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should return false when patch fails`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                val devfileContent = "test-content"
+                mockPatchReturns(createFailureResponse(404, "Not Found"))
+
+                // when
+                val result = devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should return false when exception is thrown`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                val devfileContent = "test-content"
+                mockPatchThrows(ApiException("Connection timeout"))
+
+                // when
+                val result = devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should create correct patch with devfile content`() {
+        runBlocking {
+            // given
+            val devfileContent = """
+            schemaVersion: 2.2.0
+            metadata:
+              name: my-workspace
+            components:
+              - name: tooling
+        """.trimIndent()
+
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyDevfile(namespace, workspaceName, devfileContent)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            assertThat(patchBody.has("metadata")).isTrue()
+            val metadata = patchBody.get("metadata")
+            assertThat(metadata.has("annotations")).isTrue()
+            val annotations = metadata.get("annotations")
+            assertThat(annotations.has("che.eclipse.org/local-devfile")).isTrue()
+            assertThat(annotations.get("che.eclipse.org/local-devfile").asText()).isEqualTo(devfileContent)
+        }
+    }
+
+    @Test
+    fun `#applyRestart should use JSON_MERGE_PATCH format`() {
+        runBlocking {
+            // given
+            val capturedFormat = slot<String>()
+            val mockResponse = createSuccessResponse()
+
+            every {
+                mockGenericApi.patch(
+                    any(), any(), capture(capturedFormat), any<V1Patch>(), any<PatchOptions>()
+                )
+            } returns mockResponse
+
+            // when
+            devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            assertThat(capturedFormat.captured).isEqualTo(V1Patch.PATCH_FORMAT_JSON_MERGE_PATCH)
+        }
+    }
+
+    @Test
+    fun `#applyRestart should use annotation key with forward slashes directly in Merge Patch`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyRestart(namespace, workspaceName)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            // In JSON Merge Patch, annotation keys with "/" are used directly as object keys
+            val annotations = patchBody.get("metadata").get("annotations")
+            assertThat(annotations.has("che.eclipse.org/restart-in-progress")).isTrue()
+        }
+    }
+
+    @Test
+    fun `#applyDevfile should use annotation key with forward slashes directly in Merge Patch`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.applyDevfile(namespace, workspaceName, "content")
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchBody = mapper.readTree(patchJson)
+
+            // In JSON Merge Patch, annotation keys with "/" are used directly as object keys
+            val annotations = patchBody.get("metadata").get("annotations")
+            assertThat(annotations.has("che.eclipse.org/local-devfile")).isTrue()
+        }
+    }
+
+    private fun createSuccessResponse(): KubernetesApiResponse<DynamicKubernetesObject> {
+        return mockk {
+            every { isSuccess } returns true
+        }
+    }
+
+    private fun createFailureResponse(code: Int, message: String): KubernetesApiResponse<DynamicKubernetesObject> {
+        val mockStatus = mockk<V1Status> {
+            every { this@mockk.code } returns code
+            every { this@mockk.message } returns message
+        }
+        return mockk {
+            every { isSuccess } returns false
+            every { status } returns mockStatus
+        }
+    }
+
+    private fun mockPatchReturns(response: KubernetesApiResponse<DynamicKubernetesObject>) {
+        every {
+            mockGenericApi.patch(
+                any(), any(), any(), any<V1Patch>(), any<PatchOptions>()
+            )
+        } returns response
+    }
+
+    private fun mockPatchThrows(exception: Throwable) {
+        every {
+            mockGenericApi.patch(
+                any(), any(), any(), any<V1Patch>(), any<PatchOptions>()
+            )
+        } throws exception
+    }
+
+    private fun mockPatchCaptures(capturedPatch: CapturingSlot<V1Patch>, response: KubernetesApiResponse<DynamicKubernetesObject>) {
+        every {
+            mockGenericApi.patch(
+                any(), any(), any(), capture(capturedPatch), any<PatchOptions>()
+            )
+        } returns response
+    }
+
+    @Test
+    fun `#removeDevfile should return true when patch succeeds`() {
+        runBlocking {
+            // given
+            mockPatchReturns(createSuccessResponse())
+
+            // when
+            val result = devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+            // then
+            assertThat(result).isTrue()
+
+            verify {
+                mockGenericApi.patch(
+                    namespace, workspaceName, V1Patch.PATCH_FORMAT_JSON_PATCH, any<V1Patch>(), any<PatchOptions>()
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `#removeDevfile should return false when patch fails`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchReturns(createFailureResponse(404, "Not Found"))
+
+                // when
+                val result = devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#removeDevfile should return false when exception is thrown`() {
+        LoggedErrorProcessor.executeWith<RuntimeException>(object : LoggedErrorProcessor() {
+            override fun processError(category: String, message: String, details: Array<out String>, t: Throwable?): Set<Action> {
+                return Action.NONE
+            }
+        }) {
+            runBlocking {
+                // given
+                mockPatchThrows(ApiException("Connection timeout"))
+
+                // when
+                val result = devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+                // then
+                assertThat(result).isFalse()
+            }
+        }
+    }
+
+    @Test
+    fun `#removeDevfile should create correct remove patch`() {
+        runBlocking {
+            // given
+            val capturedPatch = slot<V1Patch>()
+            mockPatchCaptures(capturedPatch, createSuccessResponse())
+
+            // when
+            devWorkspacePatch.removeDevfile(namespace, workspaceName)
+
+            // then
+            val patchJson = capturedPatch.captured.value
+            val patchOps = mapper.readTree(patchJson) as ArrayNode
+
+            assertThat(patchOps).hasSize(1)
+            val op = patchOps[0]
+            assertThat(op.get("op").asText()).isEqualTo("remove")
+            assertThat(op.get("path").asText()).isEqualTo("/metadata/annotations/che.eclipse.org~1local-devfile")
+            assertThat(op.has("value")).isFalse() // remove operation should not have a value
+        }
+    }
+
+}

--- a/che-integration-plugin/src/test/kotlin/io/github/che/devworkspace/DevWorkspaceUtilsTest.kt
+++ b/che-integration-plugin/src/test/kotlin/io/github/che/devworkspace/DevWorkspaceUtilsTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import io.kubernetes.client.openapi.ApiClient
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class DevWorkspaceUtilsTest {
+
+    @Test
+    fun `#getCurrentWorkspaceName returns workspace name when DEVWORKSPACE_NAME is set`() {
+        // given
+        val envProvider: (String) -> String? = { key -> if (key == "DEVWORKSPACE_NAME") "my-workspace" else null }
+
+        // when
+        val name = DevWorkspaceUtils.getCurrentWorkspaceName(envProvider)
+
+        // then
+        assertThat(name).isEqualTo("my-workspace")
+    }
+
+    @Test
+    fun `#getCurrentWorkspaceName returns null when DEVWORKSPACE_NAME is not set`() {
+        // given
+        val envProvider: (String) -> String? = { null }
+
+        // when
+        val name = DevWorkspaceUtils.getCurrentWorkspaceName(envProvider)
+
+        // then
+        assertThat(name).isNull()
+    }
+
+    @Test
+    fun `#getCurrentWorkspaceNamespace returns namespace when DEVWORKSPACE_NAMESPACE is set`() {
+        // given
+        val envProvider: (String) -> String? = { key -> if (key == "DEVWORKSPACE_NAMESPACE") "test-namespace" else null }
+
+        // when
+        val namespace = DevWorkspaceUtils.getCurrentWorkspaceNamespace(envProvider)
+
+        // then
+        assertThat(namespace).isEqualTo("test-namespace")
+    }
+
+    @Test
+    fun `#getCurrentWorkspaceNamespace returns null when DEVWORKSPACE_NAMESPACE is not set`() {
+        // given
+        val envProvider: (String) -> String? = { null }
+
+        // when
+        val namespace = DevWorkspaceUtils.getCurrentWorkspaceNamespace(envProvider)
+
+        // then
+        assertThat(namespace).isNull()
+    }
+
+    @Test
+    fun `#createApiClient uses KUBECONFIG env var when pointing to an existing file`(@TempDir tempDir: Path) {
+        // given
+        val kubeconfigFile = tempDir.resolve("kubeconfig").toFile()
+        kubeconfigFile.writeText("apiVersion: v1\nkind: Config")
+
+        val mockApiClient = mockk<ApiClient>()
+        val envProvider: (String) -> String? = { key ->
+            if (key == "KUBECONFIG") {
+                kubeconfigFile.absolutePath
+            } else {
+                null
+            }
+        }
+        val homeProvider: () -> String = { "/nonexistent-home-xyz" }
+        var clientFactoryCalledWith: String? = "NOT_CALLED"
+        val clientFactory: (String?) -> ApiClient = { path ->
+            clientFactoryCalledWith = path
+            mockApiClient
+        }
+
+        // when
+        val result = DevWorkspaceUtils.createApiClient(envProvider, homeProvider, clientFactory)
+
+        // then
+        assertThat(result).isEqualTo(mockApiClient)
+        assertThat(clientFactoryCalledWith).isEqualTo(kubeconfigFile.absolutePath)
+    }
+
+    @Test
+    fun `#createApiClient falls back to defaultClient when KUBECONFIG file does not exist`() {
+        // given
+        val mockApiClient = mockk<ApiClient>()
+        val envProvider: (String) -> String? = { key ->
+            if (key == "KUBECONFIG") {
+                "/nonexistent-path-xyz"
+            } else {
+                null
+            }
+        }
+        val homeProvider: () -> String = { "/nonexistent-home-xyz" }
+        var clientFactoryCalledWith: String? = "NOT_CALLED"
+        val clientFactory: (String?) -> ApiClient = { path ->
+            clientFactoryCalledWith = path
+            mockApiClient
+        }
+
+        // when
+        val result = DevWorkspaceUtils.createApiClient(envProvider, homeProvider, clientFactory)
+
+        // then
+        assertThat(result).isEqualTo(mockApiClient)
+        assertThat(clientFactoryCalledWith).isNull()  // null → defaultClient path
+    }
+
+    @Test
+    fun `#createApiClient uses default kube config when KUBECONFIG is not set but default config exists`(@TempDir tempDir: Path) {
+        // given
+        val kubeDir = tempDir.resolve(".kube").toFile()
+        kubeDir.mkdirs()
+        val kubeconfigFile = kubeDir.resolve("config")
+        kubeconfigFile.writeText("apiVersion: v1\nkind: Config")
+
+        val mockApiClient = mockk<ApiClient>()
+        val envProvider: (String) -> String? = { null }
+        val homeProvider: () -> String = { tempDir.toString() }
+        var clientFactoryCalledWith: String? = "NOT_CALLED"
+        val clientFactory: (String?) -> ApiClient = { path ->
+            clientFactoryCalledWith = path
+            mockApiClient
+        }
+
+        // when
+        val result = DevWorkspaceUtils.createApiClient(envProvider, homeProvider, clientFactory)
+
+        // then
+        assertThat(result).isEqualTo(mockApiClient)
+        assertThat(clientFactoryCalledWith).isEqualTo(kubeconfigFile.absolutePath)
+    }
+
+    @Test
+    fun `#createApiClient falls back to defaultClient when neither KUBECONFIG nor default config is available`() {
+        // given
+        val mockApiClient = mockk<ApiClient>()
+        val envProvider: (String) -> String? = { null }
+        val homeProvider: () -> String = { "/nonexistent-home-xyz" }
+        var clientFactoryCalledWith: String? = "NOT_CALLED"
+        val clientFactory: (String?) -> ApiClient = { path ->
+            clientFactoryCalledWith = path
+            mockApiClient
+        }
+
+        // when
+        val result = DevWorkspaceUtils.createApiClient(envProvider, homeProvider, clientFactory)
+
+        // then
+        assertThat(result).isEqualTo(mockApiClient)
+        assertThat(clientFactoryCalledWith).isNull()  // null → defaultClient path
+    }
+
+    @Test
+    fun `#createApiClient returns null when exception is thrown`() {
+        // given
+        val envProvider: (String) -> String? = { null }
+        val homeProvider: () -> String = { "/nonexistent-home-xyz" }
+        val clientFactory: (String?) -> ApiClient = { _ -> throw RuntimeException("Connection refused") }
+
+        // when
+        val result = DevWorkspaceUtils.createApiClient(envProvider, homeProvider, clientFactory)
+
+        // then
+        assertThat(result).isNull()
+    }
+}

--- a/che-integration-plugin/src/test/kotlin/io/github/che/devworkspace/DevfileTest.kt
+++ b/che-integration-plugin/src/test/kotlin/io/github/che/devworkspace/DevfileTest.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2026 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package io.github.che.devworkspace
+
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.vfs.VirtualFile
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+class DevfileTest {
+
+    // Sample valid devfile content
+    private val validDevfileContent = """
+        schemaVersion: 2.2.0
+        metadata:
+          name: my-workspace
+        components:
+          - name: tooling
+            container:
+              image: quay.io/devfile/universal-developer-image:latest
+    """.trimIndent()
+
+    // Valid devfile with schema version 2.0.0
+    private val validDevfileV20 = """
+        schemaVersion: 2.0.0
+        metadata:
+          name: workspace
+    """.trimIndent()
+
+    // Invalid devfile - schema version 1.0.0 (too old)
+    private val invalidDevfileOldSchema = """
+        schemaVersion: 1.0.0
+        metadata:
+          name: old-workspace
+    """.trimIndent()
+
+    // Invalid devfile - no metadata
+    private val invalidDevfileNoMetadata = """
+        schemaVersion: 2.2.0
+        components:
+          - name: tooling
+    """.trimIndent()
+
+    // Invalid devfile - no schemaVersion
+    private val invalidDevfileNoSchema = """
+        metadata:
+          name: workspace
+        components:
+          - name: tooling
+    """.trimIndent()
+
+    @Test
+    fun `#from returns null when file is null`() {
+        // given
+        val file: VirtualFile? = null
+
+        // when
+        val devfile = Devfile.from(file)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns null when file is directory`() {
+        // given
+        val mockFile = mockk<VirtualFile> {
+            every { isDirectory } returns true
+        }
+
+        // when
+        val devfile = Devfile.from(mockFile)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when valid content from editor`() {
+        // given
+        val mockFile = createMockFile(isDirectory = false)
+        val mockDocument = createMockDocument(validDevfileContent)
+        val documentProvider: (VirtualFile) -> Document? = { mockDocument }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNotNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when valid content from disk`() {
+        // given
+        val mockFile = createMockFileWithInputStream(validDevfileContent, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNotNull()
+    }
+
+    @Test
+    fun `#from returns null when schema version less than 2`() {
+        // given
+        val mockFile = createMockFileWithInputStream(invalidDevfileOldSchema, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns null when metadata is missing`() {
+        // given
+        val mockFile = createMockFileWithInputStream(invalidDevfileNoMetadata, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns null when schemaVersion is missing`() {
+        // given
+        val mockFile = createMockFileWithInputStream(invalidDevfileNoSchema, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when schema version is 2_0_0`() {
+        // given
+        val mockFile = createMockFileWithInputStream(validDevfileV20, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNotNull()
+    }
+
+    @Test
+    fun `#from returns null when exception is thrown`() {
+        // given
+        val mockFile = mockk<VirtualFile> {
+            every { isDirectory } returns false
+            every { inputStream } throws RuntimeException("Test exception")
+        }
+        val documentProvider: (VirtualFile) -> Document? = { throw RuntimeException("Document error") }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    @Test
+    fun `#getContent returns content when reading from editor`() {
+        // given
+        val mockFile = createMockFile(isDirectory = false)
+        val mockDocument = createMockDocument(validDevfileContent)
+        val documentProvider: (VirtualFile) -> Document? = { mockDocument }
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // when
+        val content = devfile?.getContent()
+
+        // then
+        assertThat(content).isEqualTo(validDevfileContent)
+    }
+
+    @Test
+    fun `#getContent returns content when reading from disk`() {
+        // given
+        val mockFile = createMockFileWithInputStream(validDevfileContent, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // when
+        val content = devfile?.getContent()
+
+        // then
+        assertThat(content).isEqualTo(validDevfileContent)
+    }
+
+    @Test
+    fun `#getContent returns null when reading fails`() {
+        // given
+        val mockFile = mockk<VirtualFile> {
+            every { isDirectory } returns false
+            every { inputStream } returns ByteArrayInputStream(validDevfileContent.toByteArray()) andThenThrows RuntimeException("Read error")
+        }
+        val documentProvider: (VirtualFile) -> Document? = { null }
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // when
+        val content = devfile?.getContent()
+
+        // then
+        assertThat(content).isNull()
+    }
+
+    @Test
+    fun `#from returns Devfile when schema version has various formats`() {
+        // given
+        val variants = listOf(
+            "schemaVersion: 2.2.0",
+            "schemaVersion: \"2.2.0\"",
+            "schemaVersion: '2.2.0'",
+            "schemaVersion:2.2.0",
+            "schemaVersion  :  2.2.0"
+        )
+
+        // when/then
+        variants.forEach { schemaLine ->
+            val content = """
+                $schemaLine
+                metadata:
+                  name: test
+            """.trimIndent()
+
+            val mockFile = createMockFileWithInputStream(content, isDirectory = false)
+            val documentProvider: (VirtualFile) -> Document? = { null }
+
+            val devfile = Devfile.from(mockFile, documentProvider)
+
+            assertThat(devfile)
+                .withFailMessage("Failed for: $schemaLine")
+                .isNotNull()
+        }
+    }
+
+    @Test
+    fun `#from returns null when schema is beyond 8KB limit`() {
+        // given
+        val largeContent = "a".repeat(8 * 1024) + "\nschemaVersion: 2.2.0\nmetadata:\n  name: test"
+        val mockFile = createMockFileWithInputStream(largeContent, isDirectory = false)
+        val documentProvider: (VirtualFile) -> Document? = { null }
+
+        // when
+        val devfile = Devfile.from(mockFile, documentProvider)
+
+        // then
+        assertThat(devfile).isNull()
+    }
+
+    // Helper: Create a mock VirtualFile
+    private fun createMockFile(isDirectory: Boolean): VirtualFile {
+        return mockk {
+            every { this@mockk.isDirectory } returns isDirectory
+        }
+    }
+
+    // Helper: Create a mock Document with specific text content
+    private fun createMockDocument(text: String): Document {
+        return mockk {
+            every { this@mockk.text } returns text
+        }
+    }
+
+    // Helper: Create a mock VirtualFile with an InputStream
+    private fun createMockFileWithInputStream(content: String, isDirectory: Boolean): VirtualFile {
+        return mockk {
+            every { this@mockk.isDirectory } returns isDirectory
+            // Mock inputStream to return a fresh ByteArrayInputStream each time it's called
+            every { inputStream } answers { ByteArrayInputStream(content.toByteArray()) }
+        }
+    }
+}


### PR DESCRIPTION
fixes https://github.com/eclipse-che/che/issues/23417
requires: https://github.com/redhat-developer/devspaces-gateway-plugin/pull/271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Restart Workspace (Devfile)" action in editor and project-tree context menus to apply a local devfile and initiate a workspace restart, with confirmation and user-facing success/error dialogs.  
<img width="300" alt="image" src="https://github.com/user-attachments/assets/341b497b-2a64-4270-aeb8-5983338c2f5a" />
<img width="300"  alt="image" src="https://github.com/user-attachments/assets/c4ee9986-a58e-45fd-9e0b-52894c57c3d4" />

  * Detects and reads local devfile content from editor or project files for restart operations.

* **Refactor**
  * Improved lifecycle and resource cleanup for the workspace activity/service to reduce leaks and ensure clean shutdown.

* **Tests**
  * Added tests covering devfile detection/content reading and devworkspace patch/restart behavior.

* **Chores**
  * Updated build/test configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->