### PR TITLE
fix: set trusted-paths for writable home, too & bump to 2026.1 (#23803)

### DIFF
--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -32,28 +32,28 @@ echo "Downloading IDE binaries..."
 ide_download_url=""
 case $ide_flavour in
   idea)
-    ide_download_url="https://download.jetbrains.com/idea/ideaIU-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/idea/idea-2026.1.tar.gz"
     ;;
   webstorm)
-    ide_download_url="https://download.jetbrains.com/webstorm/WebStorm-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/webstorm/WebStorm-2026.1.tar.gz"
     ;;
   pycharm)
-    ide_download_url="https://download.jetbrains.com/python/pycharm-professional-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/python/pycharm-2026.1.tar.gz"
     ;;
   goland)
-    ide_download_url="https://download.jetbrains.com/go/goland-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/go/goland-2026.1.tar.gz"
     ;;
   clion)
-    ide_download_url="https://download.jetbrains.com/cpp/CLion-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/cpp/CLion-2026.1.tar.gz"
     ;;
   phpstorm)
-    ide_download_url="https://download.jetbrains.com/webide/PhpStorm-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/webide/PhpStorm-2026.1.tar.gz"
     ;;
   rubymine)
-    ide_download_url="https://download.jetbrains.com/ruby/RubyMine-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/ruby/RubyMine-2026.1.tar.gz"
     ;;
   rider)
-    ide_download_url="https://download.jetbrains.com/rider/JetBrains.Rider-2025.2.tar.gz"
+    ide_download_url="https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.tar.gz"
     ;;
   *)
     echo -n "Unknown IDE is specified: $ide_flavour"

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -310,10 +310,37 @@ EOF_WORKSPACE
   echo "[INFO] Multi-project configuration complete. IntelliJ IDEA will auto-detect project types on startup."
 }
 
+create_trusted_paths_config() {
+  config_trusted_paths="$1"
+
+  if [ -f "$config_trusted_paths" ]; then
+    return
+  fi
+
+  echo "[INFO] Creating trusted-paths configuration: $config_trusted_paths"
+  mkdir -p "$(dirname "$config_trusted_paths")"
+
+  cat > "$config_trusted_paths" <<EOF_TRUSTED
+<application>
+  <component name="Trusted.Paths.Settings">
+    <option name="TRUSTED_PATHS">
+      <list>
+        <option value="$PROJECTS_ROOT" />
+      </list>
+    </option>
+  </component>
+</application>
+EOF_TRUSTED
+}
+
 start_ide_with_writable_home() {
   plugins_path="$1"
+  product_name="$2"
+
   echo "Launching IDE dev server with HOME=$HOME"
-  echo "[INFO] Opening project: $PROJECT_PATH"
+  # Create trusted-paths.xml to avoid security prompts
+  config_trusted_paths="$HOME/.config/JetBrains/$product_name/options/trusted-paths.xml"
+  create_trusted_paths_config "$config_trusted_paths"
   echo "[DEBUG] Full command: ./remote-dev-server.sh run \"$PROJECT_PATH\" -Didea.plugins.path=\"$plugins_path\""
   ./remote-dev-server.sh run "$PROJECT_PATH" -Didea.plugins.path="$plugins_path"
 }
@@ -321,45 +348,21 @@ start_ide_with_writable_home() {
 create_wrapper_script() {
   product_name="$1"
   plugins_path="$2"
+
+  # Create trusted-paths.xml for the temporary home directory
+  config_trusted_paths="$tmp_home/.config/JetBrains/$product_name/options/trusted-paths.xml"
+  create_trusted_paths_config "$config_trusted_paths"
+
   cp "$ide_server_path"/bin/remote-dev-server.sh "$ide_server_path"/bin/remote-dev-server.orig.sh
   chmod +x "$ide_server_path"/bin/remote-dev-server.orig.sh
   cat <<SCRIPT > "$ide_server_path"/bin/remote-dev-server.sh
 readonly tmp_home="/tmp/user"
 readonly ide_server_path=/idea-server/
 readonly plugins_path="$plugins_path"
-readonly product_name="$product_name"
 
 mkdir -p \$tmp_home/.config \
   \$tmp_home/.cache \
-  \$tmp_home/config/JetBrains/"\$product_name"/options \
   "\$plugins_path"
-
-config_trusted_paths="\$tmp_home/config/JetBrains/\$product_name/options/trusted-paths.xml"
-if [ ! -f "\$config_trusted_paths" ]; then
-  cat > "\$config_trusted_paths" <<'EOF_TRUSTED_HEADER'
-<application>
-  <component name="Trusted.Paths.Settings">
-    <option name="TRUSTED_PATHS">
-      <list>
-        <option value="\$PROJECT_SOURCE" />
-EOF_TRUSTED_HEADER
-
-  # Add all project subdirectories to trusted paths
-  if [ -d "\$PROJECT_SOURCE" ]; then
-    for project_dir in "\$PROJECT_SOURCE"/*; do
-      if [ -d "\$project_dir" ]; then
-        echo "        <option value=\"\$project_dir\" />" >> "\$config_trusted_paths"
-      fi
-    done
-  fi
-
-  cat >> "\$config_trusted_paths" <<'EOF_TRUSTED_FOOTER'
-      </list>
-    </option>
-  </component>
-</application>
-EOF_TRUSTED_FOOTER
-fi
 
 export HOME="\$tmp_home"
 export XDG_CONFIG_HOME="\$tmp_home/.config"
@@ -373,8 +376,8 @@ SCRIPT
 }
 
 start_ide_with_readonly_home() {
-  product_name="$1"
-  plugins_path="$2"
+  plugins_path="$1"
+  product_name="$2"
   echo "No write permission to HOME=$HOME. Launching IDE dev server with HOME=$tmp_home"
   echo "[INFO] Opening project: $PROJECT_PATH"
   echo "[DEBUG] Full command: \"$ide_server_path\"/bin/remote-dev-server.sh run \"$PROJECT_PATH\""
@@ -407,9 +410,9 @@ start_ide_server() {
   # When registry.access.redhat.com/ubi9 is used for running a user container, HOME=/ which is read-only.
   # In this case, we point remote-dev-server.sh to a writable HOME.
   if [ -w "$HOME" ]; then
-    start_ide_with_writable_home "$plugins_path"
+    start_ide_with_writable_home "$plugins_path" "$product_name"
   else
-    start_ide_with_readonly_home "$product_name" "$plugins_path"
+    start_ide_with_readonly_home "$plugins_path" "$product_name"
   fi
 }
 

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -349,10 +349,6 @@ create_wrapper_script() {
   product_name="$1"
   plugins_path="$2"
 
-  # Create trusted-paths.xml for the temporary home directory
-  config_trusted_paths="$tmp_home/.config/JetBrains/$product_name/options/trusted-paths.xml"
-  create_trusted_paths_config "$config_trusted_paths"
-
   cp "$ide_server_path"/bin/remote-dev-server.sh "$ide_server_path"/bin/remote-dev-server.orig.sh
   chmod +x "$ide_server_path"/bin/remote-dev-server.orig.sh
   cat <<SCRIPT > "$ide_server_path"/bin/remote-dev-server.sh
@@ -381,6 +377,9 @@ start_ide_with_readonly_home() {
   echo "No write permission to HOME=$HOME. Launching IDE dev server with HOME=$tmp_home"
   echo "[INFO] Opening project: $PROJECT_PATH"
   echo "[DEBUG] Full command: \"$ide_server_path\"/bin/remote-dev-server.sh run \"$PROJECT_PATH\""
+  # Create trusted-paths.xml for the temporary home directory
+  config_trusted_paths="$tmp_home/.config/JetBrains/$product_name/options/trusted-paths.xml"
+  create_trusted_paths_config "$config_trusted_paths"
   create_wrapper_script "$product_name" "$plugins_path"
   "$ide_server_path"/bin/remote-dev-server.sh run "$PROJECT_PATH"
 }


### PR DESCRIPTION
fixes https://github.com/eclipse-che/che/issues/23803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Ensure a trusted-paths configuration is generated for both user and temporary homes so IDEs recognize project root paths before startup, simplifying wrapper behavior.
  * Update bundled IDE download references to the 2026.1 releases across all supported IDE flavors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->