### PR TITLE
Fix CVE-2026-4926 by updating path-to-regexp to patched version

### DIFF
--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -714,12 +714,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-addr": {

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -14,7 +14,8 @@
   },
   "overrides": {
     "minimatch@5": "5.1.9",
-    "minimatch@3": "3.1.4"
+    "minimatch@3": "3.1.4",
+    "path-to-regexp": "8.4.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
What does this PR do?
This PR fixes https://github.com/advisories/GHSA-j3q9-mxjg-w52f.

`path-to-regexp` is updated to version `8.4.0`

What issues does this PR fix?
https://redhat.atlassian.net/browse/CRW-10599
https://redhat.atlassian.net/browse/CRW-10601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned a transitive dependency to v8.4.0 and retained existing dependency pins to ensure consistent dependency resolutions and build reproducibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->