### PR TITLE
Fix CVEs by updating qs to patched version

### DIFF
--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -736,9 +736,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -15,7 +15,8 @@
   "overrides": {
     "minimatch@5": "5.1.9",
     "minimatch@3": "3.1.4",
-    "path-to-regexp": "8.4.0"
+    "path-to-regexp": "8.4.0",
+    "qs": "6.14.2"
   },
   "type": "module"
 }


### PR DESCRIPTION
This PR fixes CVE-2025-15284 and [CVE-2026-2391](https://github.com/advisories/GHSA-w7fw-mjwx-w883)

`qs` is updated to latest version `6.14.2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Locked the transitive dependency "qs" to v6.14.2 via package resolution overrides. No public APIs or exported entities were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->