### PR TITLE
Fix CVE-2026-33750 by updating brace-expansion to patched versions

### DIFF
--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -75,15 +75,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -377,9 +368,10 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -591,6 +583,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/jake/node_modules/minimatch": {

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -13,10 +13,16 @@
     "express": "^5.2.1"
   },
   "overrides": {
-    "minimatch@5": "5.1.9",
-    "minimatch@3": "3.1.4",
-    "path-to-regexp": "8.4.0",
     "qs": "6.14.2"
+    "minimatch@5": {
+      ".": "5.1.9",
+      "brace-expansion": "2.0.3" 
+    },
+    "minimatch@3": {
+      ".": "3.1.4",
+      "brace-expansion": "1.1.13"
+    },
+    "path-to-regexp": "8.4.0"
   },
   "type": "module"
 }

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -13,7 +13,6 @@
     "express": "^5.2.1"
   },
   "overrides": {
-    "qs": "6.14.2"
     "minimatch@5": {
       ".": "5.1.9",
       "brace-expansion": "2.0.3" 
@@ -22,7 +21,8 @@
       ".": "3.1.4",
       "brace-expansion": "1.1.13"
     },
-    "path-to-regexp": "8.4.0"
+    "path-to-regexp": "8.4.0",
+    "qs": "6.14.2"
   },
   "type": "module"
 }


### PR DESCRIPTION
This PR fixes https://github.com/advisories/GHSA-f886-m6hf-6m8v.

`brace-expansion` is updated to latest versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency configurations to improve package stability and resolve transitive dependency conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->