### PR TITLE
[7.115.x] Backport CVE fixes from main

### DIFF
--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -385,9 +385,10 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -592,6 +593,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/jake/node_modules/minimatch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.4.tgz",
+      "integrity": "sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -641,17 +654,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -714,12 +714,13 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-addr": {

--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -736,9 +736,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -75,15 +75,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -377,9 +368,10 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -591,6 +583,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/brace-expansion": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/jake/node_modules/minimatch": {

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -13,10 +13,16 @@
     "express": "^5.2.1"
   },
   "overrides": {
-    "minimatch@5": "5.1.9",
-    "minimatch@3": "3.1.4",
-    "path-to-regexp": "8.4.0",
     "qs": "6.14.2"
+    "minimatch@5": {
+      ".": "5.1.9",
+      "brace-expansion": "2.0.3" 
+    },
+    "minimatch@3": {
+      ".": "3.1.4",
+      "brace-expansion": "1.1.13"
+    },
+    "path-to-regexp": "8.4.0"
   },
   "type": "module"
 }

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -15,7 +15,8 @@
   "overrides": {
     "minimatch@5": "5.1.9",
     "minimatch@3": "3.1.4",
-    "path-to-regexp": "8.4.0"
+    "path-to-regexp": "8.4.0",
+    "qs": "6.14.2"
   },
   "type": "module"
 }

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -12,5 +12,9 @@
     "ejs": "^3.1.10",
     "express": "^5.2.1"
   },
+  "overrides": {
+    "minimatch@5": "5.1.9",
+    "minimatch@3": "3.1.4"
+  },
   "type": "module"
 }

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -14,7 +14,8 @@
   },
   "overrides": {
     "minimatch@5": "5.1.9",
-    "minimatch@3": "3.1.4"
+    "minimatch@3": "3.1.4",
+    "path-to-regexp": "8.4.0"
   },
   "type": "module"
 }

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -13,7 +13,6 @@
     "express": "^5.2.1"
   },
   "overrides": {
-    "qs": "6.14.2"
     "minimatch@5": {
       ".": "5.1.9",
       "brace-expansion": "2.0.3" 
@@ -22,7 +21,8 @@
       ".": "3.1.4",
       "brace-expansion": "1.1.13"
     },
-    "path-to-regexp": "8.4.0"
+    "path-to-regexp": "8.4.0",
+    "qs": "6.14.2"
   },
   "type": "module"
 }


### PR DESCRIPTION
- minimatch
- path-to-regexp
- qs
- brace-expansion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help documentation link for workspace connection issues

* **Chores**
  * Bumped package version to 7.115.0-next
  * Pinned transitive dependency versions for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->