### PR TITLE
Migrate to Node.js 22 + fixes for UBI8/9 (#97)

### DIFF
--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -9,8 +9,8 @@
 #   Red Hat, Inc. - initial API and implementation
 
 # The image to get the Node.js binary to support running an IDE in a UBI8-based user container.
-# https://registry.access.redhat.com/ubi8/nodejs-20
-FROM registry.access.redhat.com/ubi8/nodejs-20:1-72 AS ubi8
+# https://registry.access.redhat.com/ubi8/nodejs-22
+FROM registry.access.redhat.com/ubi8/nodejs-22:1-1779338955 AS ubi8
 
 
 # FROM registry.access.redhat.com/ubi9/openjdk-21:latest as plugin-builder
@@ -41,8 +41,8 @@ FROM quay.io/eclipse/che-machine-exec:7.70.0 AS machine-exec
 
 # Base image tag updater line.
 # See https://github.com/eclipse-che/che-release/pull/90
-# https://registry.access.redhat.com/ubi9/nodejs-20
-FROM registry.access.redhat.com/ubi9/nodejs-20:9.5-1739482759
+# https://registry.access.redhat.com/ubi9/nodejs-22
+FROM registry.access.redhat.com/ubi9/nodejs-22:9.8
 
 # Dockerfile for building a container that brings everything needed to:
 # - install Jet Brains IDE to a Dev Workspace
@@ -74,6 +74,7 @@ RUN npm install
 # there no libbrotli in the image. We provide it additionally to the user's container.
 RUN mkdir /node-ubi9-ld_libs &&  \
     cp -a  \
+      /usr/lib64/libnode.so* \
       /usr/lib64/libbrotli*  \
       /usr/lib64/libssl.so.3* \
       /usr/lib64/libcrypto.so.3* \
@@ -83,6 +84,10 @@ RUN mkdir /node-ubi9-ld_libs &&  \
 
 # To make the solution backward compatible with the UBI8-based user containers.
 COPY --from=ubi8 /usr/bin/node /node-ubi8
+RUN mkdir /node-ubi8-ld_libs
+COPY --from=ubi8 \
+       /usr/lib64/libnode.so* \
+       /node-ubi8-ld_libs
 
 COPY --from=machine-exec --chown=0:0 /go/bin/che-machine-exec /machine-exec-bin/machine-exec-static
 COPY --from=plugin-builder --chown=0:0 /plugin.zip /plugin.zip

--- a/build/scripts/entrypoint-init-container.sh
+++ b/build/scripts/entrypoint-init-container.sh
@@ -77,6 +77,7 @@ cp /entrypoint-volume.sh "$ide_server_path"
 # It will be copied to the user container if it's absent.
 cp /usr/bin/node "$ide_server_path"/node-ubi9
 cp /node-ubi8 "$ide_server_path"/node-ubi8
+cp -r /node-ubi8-ld_libs "$ide_server_path"/node-ubi8-ld_libs
 cp -r /node-ubi9-ld_libs "$ide_server_path"/node-ubi9-ld_libs
 
 # Copy the folder with machine-exec binaries compatible with UBI8/9

--- a/build/scripts/entrypoint-volume.sh
+++ b/build/scripts/entrypoint-volume.sh
@@ -101,6 +101,7 @@ start_status_app() {
   case "${openssl_version}" in
   *"1"*)
     mv "$ide_server_path"/node-ubi8 "$ide_server_path"/node
+    custom_ld_path="$ide_server_path/node-ubi8-ld_libs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
     ;;
   *"3"*)
     mv "$ide_server_path"/node-ubi9 "$ide_server_path"/node


### PR DESCRIPTION
forward-port of https://github.com/che-incubator/jetbrains-ide-dev-server/pull/97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime from version 20 to version 22 in all container base images
  * Refactored container image library staging to separately manage shared libraries for different environment variants
  * Enhanced initialization and volume preparation scripts to properly configure runtime library paths and ensure correct library resolution during container execution
  * Improved shared library management in init container workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/jetbrains-ide-dev-server/pull/98?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->