### PR TITLE
fix(deps): bump qs to 6.15.2 to address CVE-2026-8723

### DIFF
--- a/status-app/package-lock.json
+++ b/status-app/package-lock.json
@@ -738,9 +738,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/status-app/package.json
+++ b/status-app/package.json
@@ -22,7 +22,7 @@
       "brace-expansion": "1.1.13"
     },
     "path-to-regexp": "8.4.0",
-    "qs": "6.14.2"
+    "qs": "6.15.2"
   },
   "type": "module"
 }


### PR DESCRIPTION
fixes https://github.com/che-incubator/jetbrains-ide-dev-server/security/dependabot/23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to improve application stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->